### PR TITLE
ci: add GitHub Actions for tests and tagged Docker/binary releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,126 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+# Cancel superseded runs on the same ref (e.g. rapid PR pushes).
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+  # Keep the build hermetic; the workspace vendors its own Postgres share tree.
+  RUST_BACKTRACE: 1
+
+jobs:
+  # ---------------------------------------------------------------------------
+  # Formatting — cheap, fast feedback, no system deps required.
+  # ---------------------------------------------------------------------------
+  fmt:
+    name: rustfmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Install Rust (stable + rustfmt)
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+      - name: cargo fmt --check
+        run: cargo fmt --all --check
+
+  # ---------------------------------------------------------------------------
+  # Clippy — advisory only for now. `continue-on-error` keeps the job from
+  # failing the run while the workspace is brought up to a clean lint baseline;
+  # flip it off (or drop it) to start enforcing.
+  # ---------------------------------------------------------------------------
+  clippy:
+    name: clippy (advisory)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install Rust (stable + clippy)
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+
+      - name: Cache cargo build
+        uses: Swatinem/rust-cache@v2
+
+      - name: Install build dependencies
+        run: |
+          set -eux
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            build-essential pkg-config \
+            libicu-dev libssl-dev libldap2-dev libpam0g-dev
+
+      - name: cargo clippy
+        run: cargo clippy --workspace --all-targets --locked
+
+  # ---------------------------------------------------------------------------
+  # Build the pgrust `postgres` binary and run the Postgres regression suite
+  # against it, exactly as documented in the README.
+  # ---------------------------------------------------------------------------
+  build-and-test:
+    name: build + regression
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install Rust (stable)
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo build
+        uses: Swatinem/rust-cache@v2
+
+      - name: Install build + client dependencies
+        run: |
+          set -eux
+          # PGDG apt repo — provides the PostgreSQL 18 `psql` client the
+          # regression runner needs (its one external dependency).
+          sudo install -d /usr/share/postgresql-common/pgdg
+          sudo wget -qO /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc \
+            https://www.postgresql.org/media/keys/ACCC4CF8.asc
+          echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" \
+            | sudo tee /etc/apt/sources.list.d/pgdg.list
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            build-essential pkg-config \
+            libicu-dev libssl-dev libldap2-dev libpam0g-dev \
+            postgresql-client-18
+
+      - name: Build release binary
+        env:
+          # Bake the vendored Postgres 18.3 share tree (tz data + bootstrap
+          # templates) into the binary, matching the README build recipe.
+          PGRUST_PGSHAREDIR: ${{ github.workspace }}/vendor/postgres-18.3/share
+        run: cargo build --release --locked --bin postgres
+
+      - name: Run regression tests
+        env:
+          PGRUST_BIN: ${{ github.workspace }}/target/release/postgres
+        run: |
+          # The PGDG client installs psql at /usr/lib/postgresql/18/bin.
+          export PATH="/usr/lib/postgresql/18/bin:$PATH"
+          scripts/run-regression
+
+      - name: Upload regression diffs on failure
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: regression-output
+          path: |
+            **/regression.diffs
+            **/regression.out
+          if-no-files-found: ignore
+          retention-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - name: Install Rust (stable + rustfmt)
         uses: dtolnay/rust-toolchain@stable
         with:
@@ -47,6 +49,8 @@ jobs:
     continue-on-error: true
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Install Rust (stable + clippy)
         uses: dtolnay/rust-toolchain@stable
@@ -76,6 +80,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Install Rust (stable)
         uses: dtolnay/rust-toolchain@stable
@@ -109,18 +115,25 @@ jobs:
       - name: Run regression tests
         env:
           PGRUST_BIN: ${{ github.workspace }}/target/release/postgres
+          # Pin the runner's output dir (it otherwise defaults to a throwaway
+          # mktemp dir) so the failure step below can find and upload the
+          # per-test *.out results and server logs it writes there.
+          OUTDIR: ${{ github.workspace }}/regression-output
         run: |
           # The PGDG client installs psql at /usr/lib/postgresql/18/bin.
           export PATH="/usr/lib/postgresql/18/bin:$PATH"
           scripts/run-regression
 
-      - name: Upload regression diffs on failure
+      - name: Upload regression output on failure
         if: failure()
         uses: actions/upload-artifact@v7
         with:
           name: regression-output
+          # run-regression writes <test>.out results plus initdb/postmaster logs
+          # into OUTDIR; test diffs are echoed to the job log. Upload everything
+          # except the disposable pgdata under data/.
           path: |
-            **/regression.diffs
-            **/regression.out
+            regression-output/**
+            !regression-output/data/**
           if-no-files-found: ignore
           retention-days: 7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,9 +16,9 @@ concurrency:
   group: release-${{ github.ref }}
   cancel-in-progress: false
 
+# Default to read-only; each job below elevates only what it needs.
 permissions:
-  contents: write # create the GitHub Release + upload assets
-  packages: write # push images to GHCR
+  contents: read
 
 env:
   CARGO_TERM_COLOR: always
@@ -34,10 +34,14 @@ jobs:
   docker:
     name: docker image
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write # push images to GHCR
     steps:
       - uses: actions/checkout@v7
         with:
           ref: ${{ github.event.inputs.tag || github.ref }}
+          persist-credentials: false
 
       - name: Detect Docker Hub credentials
         id: dockerhub
@@ -51,6 +55,29 @@ jobs:
             echo "::notice::Docker Hub secrets not set — pushing to GHCR only."
           fi
 
+      # Derive the image tags from the *resolved* release tag rather than from
+      # github.ref, so a workflow_dispatch rebuild (github.ref is the branch,
+      # not the tag) still emits the right semver tags. The floating major /
+      # major.minor / latest tags are applied only for stable (non-prerelease)
+      # versions. TAG comes in via env to keep it out of the shell text.
+      - name: Resolve release version
+        id: ver
+        env:
+          TAG: ${{ github.event.inputs.tag || github.ref_name }}
+        run: |
+          set -eu
+          ver="${TAG#refs/tags/}"        # tolerate a full ref
+          ver="${ver#v}"                 # v0.2.0 -> 0.2.0
+          major="${ver%%.*}"
+          rest="${ver#*.}"; minor="${rest%%.*}"
+          case "$ver" in *-*) stable=false ;; *) stable=true ;; esac
+          {
+            echo "version=${ver}"
+            echo "major=${major}"
+            echo "majorminor=${major}.${minor}"
+            echo "stable=${stable}"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Docker metadata (tags + labels)
         id: meta
         uses: docker/metadata-action@v6
@@ -58,11 +85,12 @@ jobs:
           images: |
             ghcr.io/${{ github.repository }}
             ${{ steps.dockerhub.outputs.images }}
+          flavor: latest=false
           tags: |
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
-            type=raw,value=latest,enable=${{ !contains(github.ref, '-') }}
+            type=raw,value=${{ steps.ver.outputs.version }}
+            type=raw,value=${{ steps.ver.outputs.majorminor }},enable=${{ steps.ver.outputs.stable == 'true' }}
+            type=raw,value=${{ steps.ver.outputs.major }},enable=${{ steps.ver.outputs.stable == 'true' }}
+            type=raw,value=latest,enable=${{ steps.ver.outputs.stable == 'true' }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -100,6 +128,8 @@ jobs:
   binaries:
     name: binary (${{ matrix.target }})
     runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -112,6 +142,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           ref: ${{ github.event.inputs.tag || github.ref }}
+          persist-credentials: false
 
       - name: Install Rust (stable)
         uses: dtolnay/rust-toolchain@stable
@@ -120,6 +151,9 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           key: ${{ matrix.target }}
+          # Read-only: release runs accept a user-supplied tag input, so don't
+          # let them write back to the shared cache (cache-poisoning vector).
+          save-if: false
 
       - name: Install build dependencies
         run: |
@@ -136,10 +170,16 @@ jobs:
 
       - name: Package artifact
         id: package
+        env:
+          # Pass the (attacker-controllable) tag input through the environment
+          # instead of interpolating it into the shell text — avoids template
+          # injection via shell metacharacters in the tag.
+          TAG: ${{ github.event.inputs.tag || github.ref_name }}
+          TARGET: ${{ matrix.target }}
         run: |
           set -eux
-          version="${{ github.event.inputs.tag || github.ref_name }}"
-          name="pgrust-${version}-${{ matrix.target }}"
+          version="${TAG}"
+          name="pgrust-${version}-${TARGET}"
           staging="dist/${name}"
           mkdir -p "${staging}/bin" "${staging}/share"
           cp target/release/postgres "${staging}/bin/pgrust-postgres"
@@ -164,6 +204,8 @@ jobs:
     name: github release
     needs: [docker, binaries]
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # create the GitHub Release + upload assets
     steps:
       - name: Download binary artifacts
         uses: actions/download-artifact@v8

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,184 @@
+name: Release
+
+# Cut a release when a semver tag is pushed, e.g.:
+#   git tag v0.2.0 && git push origin v0.2.0
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing tag to (re)build a release for, e.g. v0.2.0"
+        required: true
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write # create the GitHub Release + upload assets
+  packages: write # push images to GHCR
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  # ---------------------------------------------------------------------------
+  # Build the drop-in `postgres` Docker image and push it to GHCR (always) and
+  # Docker Hub (only when DOCKERHUB_USERNAME + DOCKERHUB_TOKEN secrets are set).
+  #
+  # Built for linux/amd64 only: the multi-stage Dockerfile compiles the full
+  # ~1.4k-crate Rust workspace, which is impractical under arm64 QEMU emulation.
+  # ---------------------------------------------------------------------------
+  docker:
+    name: docker image
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.inputs.tag || github.ref }}
+
+      - name: Detect Docker Hub credentials
+        id: dockerhub
+        run: |
+          if [ -n "${{ secrets.DOCKERHUB_USERNAME }}" ] && [ -n "${{ secrets.DOCKERHUB_TOKEN }}" ]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+            echo "images=docker.io/${{ secrets.DOCKERHUB_USERNAME }}/pgrust" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "images=" >> "$GITHUB_OUTPUT"
+            echo "::notice::Docker Hub secrets not set — pushing to GHCR only."
+          fi
+
+      - name: Docker metadata (tags + labels)
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: |
+            ghcr.io/${{ github.repository }}
+            ${{ steps.dockerhub.outputs.images }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=raw,value=latest,enable=${{ !contains(github.ref, '-') }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Log in to Docker Hub
+        if: steps.dockerhub.outputs.enabled == 'true'
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  # ---------------------------------------------------------------------------
+  # Build self-contained release binaries (the pgrust `postgres` binary plus the
+  # vendored Postgres 18.3 share tree) for linux x86_64 and arm64, then attach
+  # them to the GitHub Release.
+  # ---------------------------------------------------------------------------
+  binaries:
+    name: binary (${{ matrix.target }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-latest
+            target: x86_64-linux
+          - runner: ubuntu-24.04-arm
+            target: aarch64-linux
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.inputs.tag || github.ref }}
+
+      - name: Install Rust (stable)
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo build
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ matrix.target }}
+
+      - name: Install build dependencies
+        run: |
+          set -eux
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            build-essential pkg-config \
+            libicu-dev libssl-dev libldap2-dev libpam0g-dev
+
+      - name: Build release binary
+        env:
+          PGRUST_PGSHAREDIR: ${{ github.workspace }}/vendor/postgres-18.3/share
+        run: cargo build --release --locked --bin postgres
+
+      - name: Package artifact
+        id: package
+        run: |
+          set -eux
+          version="${{ github.event.inputs.tag || github.ref_name }}"
+          name="pgrust-${version}-${{ matrix.target }}"
+          staging="dist/${name}"
+          mkdir -p "${staging}/bin" "${staging}/share"
+          cp target/release/postgres "${staging}/bin/pgrust-postgres"
+          cp -a vendor/postgres-18.3/share/. "${staging}/share/"
+          cp README.md LICENSE "${staging}/"
+          tar -C dist -czf "${name}.tar.gz" "${name}"
+          sha256sum "${name}.tar.gz" > "${name}.tar.gz.sha256"
+          echo "archive=${name}.tar.gz" >> "$GITHUB_OUTPUT"
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: pgrust-${{ matrix.target }}
+          path: |
+            ${{ steps.package.outputs.archive }}
+            ${{ steps.package.outputs.archive }}.sha256
+
+  # ---------------------------------------------------------------------------
+  # Publish the GitHub Release with the built binaries attached.
+  # ---------------------------------------------------------------------------
+  release:
+    name: github release
+    needs: [docker, binaries]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download binary artifacts
+        uses: actions/download-artifact@v8
+        with:
+          pattern: pgrust-*
+          path: artifacts
+          merge-multiple: true
+
+      - name: Publish release
+        uses: softprops/action-gh-release@v3
+        with:
+          tag_name: ${{ github.event.inputs.tag || github.ref_name }}
+          generate_release_notes: true
+          draft: false
+          prerelease: ${{ contains(github.event.inputs.tag || github.ref_name, '-') }}
+          files: |
+            artifacts/*.tar.gz
+            artifacts/*.sha256


### PR DESCRIPTION
## Summary

Adds GitHub Actions CI and release automation. No source changes — only two workflow files under `.github/workflows/`.

### `ci.yml` — on push/PR to `main` (+ manual dispatch)
- **rustfmt** — `cargo fmt --all --check`.
- **clippy (advisory)** — `cargo clippy --workspace --all-targets --locked`, marked `continue-on-error: true` so it reports without gating (flip off once a clean baseline exists).
- **build + regression** — installs build deps + a PGDG `psql` 18 client, builds `cargo build --release --locked --bin postgres` (with `PGRUST_PGSHAREDIR` → the vendored 18.3 share tree), then runs `scripts/run-regression` exactly as the README documents. Uploads `regression.diffs`/`.out` on failure.

### `release.yml` — on `v*` tags (+ manual dispatch with a tag input)
- **docker** — builds the drop-in Dockerfile and pushes to **GHCR** (`ghcr.io/<owner>/pgrust`, semver + `latest` via `docker/metadata-action`). Also pushes to **Docker Hub** only when `DOCKERHUB_USERNAME`/`DOCKERHUB_TOKEN` secrets are set. `linux/amd64` only (the ~1.4k-crate build is impractical under arm64 QEMU), with GHA layer caching.
- **binaries** — matrix build on native x86_64 + arm64 runners; packages self-contained `pgrust-<ver>-<target>.tar.gz` tarballs (binary + vendored PG 18.3 share tree + README/LICENSE) with SHA-256 sums.
- **release** — publishes a GitHub Release with auto-generated notes and the tarballs/checksums attached.

## Notes
- GHCR push needs no secrets (uses the built-in `GITHUB_TOKEN`). Docker Hub is optional and gated on secrets, so this is safe to merge as-is.
- All actions pinned to current latest majors: `checkout@v7`, `upload-artifact@v7`, `download-artifact@v8`, `rust-cache@v2`, `metadata-action@v6`, `setup-buildx-action@v4`, `login-action@v4`, `build-push-action@v7`, `action-gh-release@v3`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated CI workflow that runs Rust formatting checks, linting, and build/regression tests on pushes and pull requests.
  * Added a release pipeline that builds and publishes Docker images, packaged binaries, and GitHub Releases from version tags (including checksums).
* **Bug Fixes**
  * Improved failure visibility by automatically uploading regression artifacts on test failures.
  * Reduced wasted compute by canceling in-progress CI runs for the same branch or tag.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->