### PR TITLE
Register xml_recv builtin for extended protocol

### DIFF
--- a/crates/_support/seam/init/src/builtin_gap_baseline.rs
+++ b/crates/_support/seam/init/src/builtin_gap_baseline.rs
@@ -177,7 +177,6 @@ pub const KNOWN_GAP: &[BaselineGap] = &[
     (2856, "pg_timezone_names", BuiltinGapKind::NotRegistered),
     (2857, "pg_stat_get_backend_xact_start", BuiltinGapKind::NotRegistered),
     (2859, "pg_stat_get_buf_alloc", BuiltinGapKind::NotRegistered),
-    (2898, "xml_recv", BuiltinGapKind::NotRegistered),
     (2931, "xpath", BuiltinGapKind::NotRegistered),
     (2947, "pg_snapshot_xip", BuiltinGapKind::NotRegistered),
     (3035, "pg_listening_channels", BuiltinGapKind::NotRegistered),

--- a/crates/backend/utils/adt/adt_xml/src/fmgr_builtins.rs
+++ b/crates/backend/utils/adt/adt_xml/src/fmgr_builtins.rs
@@ -24,6 +24,16 @@ use ::fmgr::{BuiltinFunction, FunctionCallInfoBaseData, PgFnNative};
 // Argument readers / result writers.
 // ---------------------------------------------------------------------------
 
+/// A `recv` function's `internal` (StringInfo) argument, delivered as its raw
+/// message-buffer bytes on the by-ref lane (no varlena header stripping).
+#[inline]
+fn arg_recv_payload<'a>(fcinfo: &'a FunctionCallInfoBaseData, i: usize) -> &'a [u8] {
+    fcinfo
+        .ref_arg(i)
+        .and_then(|p| p.as_varlena())
+        .expect("xml fn: by-ref recv (StringInfo) arg missing from by-ref lane")
+}
+
 /// A `text` arg's detoasted `VARDATA_ANY` payload bytes on the by-ref lane
 /// (C: `VARDATA_ANY(data)` / `VARSIZE_ANY_EXHDR(data)`).
 #[inline]
@@ -127,6 +137,14 @@ fn fc_xml_out(fcinfo: &mut FunctionCallInfoBaseData) -> PgResult<Datum> {
     let x = arg_text_bytes(fcinfo, 0);
     let out = crate::xml_out(x)?;
     Ok(ret_cstring(fcinfo, out))
+}
+
+/// `xml_recv(internal) -> xml` (OID 2898) — validate wire bytes, convert to
+/// server encoding, and return the stored `xml` payload bytes.
+fn fc_xml_recv(fcinfo: &mut FunctionCallInfoBaseData) -> PgResult<Datum> {
+    let buf = arg_recv_payload(fcinfo, 0);
+    let out = crate::xml_recv(buf)?;
+    Ok(ret_varlena(fcinfo, out))
 }
 
 /// `xmlcomment(text)` (OID 2895) — `<!--text-->`.
@@ -498,6 +516,7 @@ pub fn register_xml_builtins() {
         // text<->xml casts, so xml values parse, print, and round-trip.
         builtin(2893, "xml_in", 1, true, false, fc_xml_in),
         builtin(2894, "xml_out", 1, true, false, fc_xml_out),
+        builtin(2898, "xml_recv", 1, true, false, fc_xml_recv),
         builtin(2895, "xmlcomment", 1, true, false, fc_xmlcomment),
         builtin(2896, "texttoxml", 1, true, false, fc_texttoxml),
         builtin(2922, "xmltotext", 1, true, false, fc_xmltotext),


### PR DESCRIPTION
## Summary
- Register builtin OID 2898 (xml_recv) in the fmgr builtin registry so extended query protocol can decode XML parameters.
- Remove xml_recv from the known-gap baseline.

Fixes malisper/pgrust#14.

## Test plan
- Reproduce the reported scenario: extended-query bind of an xml parameter should no longer error with internal function xml_recv is not in internal lookup table.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added support for an XML binary receive operation, improving compatibility when reading XML values through the runtime.
  * Removed a previously known gap for this XML builtin, so the registry now matches expected behavior more closely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->