### PR TITLE
docs: link pgrust updates signup

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
   <span>&nbsp;&nbsp;|&nbsp;&nbsp;</span>
   <a href="https://discord.gg/FZZ4dbdvwU">Discord</a>
   <span>&nbsp;&nbsp;|&nbsp;&nbsp;</span>
-  <a href="https://malisper.me/subscribe/">Mailing list</a>
+  <a href="https://pgrust.com/#updates">Get pgrust updates</a>
   <span>&nbsp;&nbsp;|&nbsp;&nbsp;</span>
   <a href="https://github.com/malisper/pgrust/issues">Issues</a>
 </div>
@@ -33,6 +33,11 @@ pgrust is disk compatible with Postgres and can boot from an existing Postgres
 The goal is to make Postgres easier to change from the inside: keep the behavior
 Postgres-shaped, keep the real Postgres tests as the oracle, and use Rust plus
 AI-assisted programming to explore deeper server changes.
+
+## Follow pgrust
+
+[Get project updates by email](https://pgrust.com/#updates), including new
+releases, compatibility milestones, and architecture experiments.
 
 ## Status
 
@@ -166,7 +171,7 @@ a Postgres improvement you want to see first.
 
 - Email: maintainers@pgrust.com
 - Discord: https://discord.gg/FZZ4dbdvwU
-- Mailing list: https://malisper.me/subscribe/
+- Project updates: https://pgrust.com/#updates
 
 ## License
 


### PR DESCRIPTION
## Summary

- point the README mailing-list links to the project-owned signup at `pgrust.com/#updates`
- add a short Follow pgrust section near the top
- rename the contact entry from Mailing list to Project updates

The signup page is live and uses double opt-in.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project navigation and contact links.
  * Replaced mailing-list references with links for receiving project updates.
  * Added a new “Follow pgrust” section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->