### PR TITLE
fix: hash fn panics with 'by-reference argument missing from the by-ref lane' on SQLsmith MERGE query

### DIFF
--- a/crates/backend/access/hashfunc/src/lib.rs
+++ b/crates/backend/access/hashfunc/src/lib.rs
@@ -22,14 +22,14 @@
 #![allow(non_snake_case)]
 #![allow(clippy::result_large_err)]
 
+use ::datum::Datum;
+use ::fmgr::{FunctionCallInfoBaseData, PgFnNative};
 use ::hashfn::{
     hash_bytes as hash_any, hash_bytes_extended as hash_any_extended,
     hash_bytes_uint32 as hash_uint32, hash_bytes_uint32_extended as hash_uint32_extended,
 };
 use ::types_core::Oid;
-use ::datum::Datum;
-use ::types_error::{PgResult, ERRCODE_INDETERMINATE_COLLATION, ERROR};
-use ::fmgr::{FunctionCallInfoBaseData, PgFnNative};
+use ::types_error::{PgError, PgResult, ERRCODE_INDETERMINATE_COLLATION, ERROR};
 
 use ::oid_seams::check_valid_oidvector;
 use ::pg_locale_seams::{collation_is_deterministic, pg_strxfrm};
@@ -376,11 +376,13 @@ fn arg_word(fcinfo: &FunctionCallInfoBaseData, i: usize) -> usize {
 /// (`PG_GETARG_TEXT_PP` / `PG_GETARG_NAME` / `PG_GETARG_VARLENA_PP` /
 /// `PG_GETARG_POINTER` for the oidvector image).
 #[inline]
-fn arg_bytes<'a>(fcinfo: &'a FunctionCallInfoBaseData, i: usize) -> &'a [u8] {
+fn arg_bytes<'a>(fcinfo: &'a FunctionCallInfoBaseData, i: usize) -> PgResult<&'a [u8]> {
     fcinfo
         .ref_arg(i)
         .and_then(|p| p.as_varlena())
-        .expect("hash fn: by-reference argument missing from the by-ref lane")
+        .ok_or_else(|| {
+            PgError::error("hash fn: by-reference argument missing from the by-ref lane")
+        })
 }
 
 /// `NameStr(*PG_GETARG_NAME(i))` length-trimmed bytes: a `name` value crosses
@@ -392,10 +394,10 @@ fn arg_bytes<'a>(fcinfo: &'a FunctionCallInfoBaseData, i: usize) -> &'a [u8] {
 /// `hashtext` for the same string, breaking the cross-type text/name hash
 /// opfamily 1995 invariant that hashed IN/ANY SubPlans rely on.)
 #[inline]
-fn arg_name_str<'a>(fcinfo: &'a FunctionCallInfoBaseData, i: usize) -> &'a [u8] {
-    let image = arg_bytes(fcinfo, i);
+fn arg_name_str<'a>(fcinfo: &'a FunctionCallInfoBaseData, i: usize) -> PgResult<&'a [u8]> {
+    let image = arg_bytes(fcinfo, i)?;
     let len = image.iter().position(|&b| b == 0).unwrap_or(image.len());
-    &image[..len]
+    Ok(&image[..len])
 }
 
 /// `VARDATA_ANY` of a text/bytea varlena argument so the core hashes
@@ -406,13 +408,13 @@ fn arg_name_str<'a>(fcinfo: &'a FunctionCallInfoBaseData, i: usize) -> &'a [u8] 
 /// values. Skip ONE byte for a short header, else the 4-byte header. No-op while
 /// packing is off.
 #[inline]
-fn arg_varlena_payload<'a>(fcinfo: &'a FunctionCallInfoBaseData, i: usize) -> &'a [u8] {
-    let image = arg_bytes(fcinfo, i);
-    match image.first() {
+fn arg_varlena_payload<'a>(fcinfo: &'a FunctionCallInfoBaseData, i: usize) -> PgResult<&'a [u8]> {
+    let image = arg_bytes(fcinfo, i)?;
+    Ok(match image.first() {
         Some(&h) if h != 0x01 && (h & 0x01) == 0x01 => &image[1..],
         Some(_) if image.len() >= 4 => &image[4..],
         _ => &[],
-    }
+    })
 }
 
 /// `PG_RETURN_UINT32` — box a 32-bit hash into the fmgr-ABI result word.
@@ -482,41 +484,51 @@ fn fc_hashfloat8extended(fcinfo: &mut FunctionCallInfoBaseData) -> PgResult<Datu
     )))
 }
 fn fc_hashoidvector(fcinfo: &mut FunctionCallInfoBaseData) -> PgResult<Datum> {
-    Ok(ret_u32(hashoidvector(arg_bytes(fcinfo, 0))?))
+    Ok(ret_u32(hashoidvector(arg_bytes(fcinfo, 0)?)?))
 }
 fn fc_hashoidvectorextended(fcinfo: &mut FunctionCallInfoBaseData) -> PgResult<Datum> {
     let seed = arg_word(fcinfo, 1) as u64;
-    Ok(ret_u64(hashoidvectorextended(arg_bytes(fcinfo, 0), seed)?))
+    Ok(ret_u64(hashoidvectorextended(arg_bytes(fcinfo, 0)?, seed)?))
 }
 fn fc_hashname(fcinfo: &mut FunctionCallInfoBaseData) -> PgResult<Datum> {
-    Ok(ret_u32(hashname(arg_name_str(fcinfo, 0))))
+    Ok(ret_u32(hashname(arg_name_str(fcinfo, 0)?)))
 }
 fn fc_hashnameextended(fcinfo: &mut FunctionCallInfoBaseData) -> PgResult<Datum> {
     let seed = arg_word(fcinfo, 1) as u64;
-    Ok(ret_u64(hashnameextended(arg_name_str(fcinfo, 0), seed)))
+    Ok(ret_u64(hashnameextended(arg_name_str(fcinfo, 0)?, seed)))
 }
 fn fc_hashtext(fcinfo: &mut FunctionCallInfoBaseData) -> PgResult<Datum> {
     let collid = fcinfo.fncollation;
-    Ok(ret_u32(hashtext(arg_varlena_payload(fcinfo, 0), collid)?))
+    Ok(ret_u32(hashtext(arg_varlena_payload(fcinfo, 0)?, collid)?))
 }
 fn fc_hashtextextended(fcinfo: &mut FunctionCallInfoBaseData) -> PgResult<Datum> {
     let collid = fcinfo.fncollation;
     let seed = arg_word(fcinfo, 1) as u64;
-    Ok(ret_u64(hashtextextended(arg_varlena_payload(fcinfo, 0), collid, seed)?))
+    Ok(ret_u64(hashtextextended(
+        arg_varlena_payload(fcinfo, 0)?,
+        collid,
+        seed,
+    )?))
 }
 fn fc_hashvarlena(fcinfo: &mut FunctionCallInfoBaseData) -> PgResult<Datum> {
-    Ok(ret_u32(hashvarlena(arg_varlena_payload(fcinfo, 0))))
+    Ok(ret_u32(hashvarlena(arg_varlena_payload(fcinfo, 0)?)))
 }
 fn fc_hashvarlenaextended(fcinfo: &mut FunctionCallInfoBaseData) -> PgResult<Datum> {
     let seed = arg_word(fcinfo, 1) as u64;
-    Ok(ret_u64(hashvarlenaextended(arg_varlena_payload(fcinfo, 0), seed)))
+    Ok(ret_u64(hashvarlenaextended(
+        arg_varlena_payload(fcinfo, 0)?,
+        seed,
+    )))
 }
 fn fc_hashbytea(fcinfo: &mut FunctionCallInfoBaseData) -> PgResult<Datum> {
-    Ok(ret_u32(hashbytea(arg_varlena_payload(fcinfo, 0))))
+    Ok(ret_u32(hashbytea(arg_varlena_payload(fcinfo, 0)?)))
 }
 fn fc_hashbyteaextended(fcinfo: &mut FunctionCallInfoBaseData) -> PgResult<Datum> {
     let seed = arg_word(fcinfo, 1) as u64;
-    Ok(ret_u64(hashbyteaextended(arg_varlena_payload(fcinfo, 0), seed)))
+    Ok(ret_u64(hashbyteaextended(
+        arg_varlena_payload(fcinfo, 0)?,
+        seed,
+    )))
 }
 
 // pg_proc OIDs (pg_proc.dat).

--- a/crates/backend/access/hashfunc/src/tests.rs
+++ b/crates/backend/access/hashfunc/src/tests.rs
@@ -7,6 +7,8 @@
 //! single-threaded).
 
 use super::*;
+use ::datum::NullableDatum;
+use ::fmgr::boundary::RefPayload;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Once;
 
@@ -186,6 +188,43 @@ fn name_varlena_bytea_hash_their_image() {
     assert_eq!(
         hashnameextended(bytes, seed),
         hashfn::hash_bytes_extended(bytes, seed)
+    );
+}
+
+#[test]
+fn hashtext_adapter_accepts_short_and_long_varlena_headers() {
+    install_seams();
+    DETERMINISTIC.store(true, Ordering::SeqCst);
+    let payload = b"hash join key";
+
+    let mut short = Vec::with_capacity(payload.len() + 1);
+    short.push((((payload.len() + 1) << 1) | 1) as u8);
+    short.extend_from_slice(payload);
+
+    let mut long = Vec::with_capacity(payload.len() + 4);
+    long.extend_from_slice(&::datum::varlena::set_varsize_4b(payload.len() + 4));
+    long.extend_from_slice(payload);
+
+    for image in [short, long] {
+        let mut fcinfo = FunctionCallInfoBaseData::new(None, 1, 100, None, None);
+        fcinfo.args = vec![NullableDatum::value(Datum::null())];
+        fcinfo.ref_args = vec![Some(RefPayload::Varlena(image))];
+        assert_eq!(
+            fc_hashtext(&mut fcinfo).unwrap().as_u32(),
+            hashfn::hash_bytes(payload)
+        );
+    }
+}
+
+#[test]
+fn missing_byref_hash_argument_returns_error() {
+    let mut fcinfo = FunctionCallInfoBaseData::new(None, 1, 100, None, None);
+    fcinfo.args = vec![NullableDatum::value(Datum::from_usize(1))];
+
+    let err = fc_hashtext(&mut fcinfo).unwrap_err();
+    assert_eq!(
+        err.message(),
+        "hash fn: by-reference argument missing from the by-ref lane"
     );
 }
 

--- a/crates/backend/executor/execExprInterp/src/eval_scalar.rs
+++ b/crates/backend/executor/execExprInterp/src/eval_scalar.rs
@@ -609,20 +609,23 @@ pub fn exec_rowcompare_step<'mcx>(
 /// argument cell into the call frame, and surface the previous (intermediate)
 /// hash via `iresult`. The argument crosses to the hash function via the
 /// canonical [`DatumV`] lane (the by-reference-capable form), so a by-ref
-/// text/name/varchar key survives the gather — the bare-word `word_of`
-/// downgrade panics on such a value (the type's hash function, e.g.
-/// `hashtext`/`namehash`, reads its argument by reference).
+/// text/name/varchar key survives the gather. A legacy `Const` may still carry
+/// a by-reference value as its C pointer word in `DatumV::ByVal`; normalize that
+/// audited compatibility form back to a self-contained `DatumV::ByRef` before
+/// crossing fmgr (the type's hash function, e.g. `hashtext`/`hashname`, reads
+/// its argument by reference).
 /// Returns `(fn_oid, collation, args, arg0_isnull, iresult)`.
 fn hashdatum_step_inputs<'mcx>(
+    mcx: mcx::Mcx<'mcx>,
     state: &ExprState<'mcx>,
     op: usize,
-) -> (
+) -> PgResult<(
     ::types_core::primitive::Oid,
     ::types_core::primitive::Oid,
     Vec<DatumV<'mcx>>,
     bool,
     u32,
-) {
+)> {
     match step_data(state, op) {
         ExprEvalStepData::HashDatum {
             finfo,
@@ -640,19 +643,112 @@ fn hashdatum_step_inputs<'mcx>(
             // fcinfo->args[0] <- the hash-key cell the sub-expression evaluated.
             // Carry the full canonical Datum image (by-value word OR by-reference
             // referent bytes) so the hash function reads a by-ref key correctly.
-            let c = state.result_cells.get(*arg_cell);
-            let args = vec![c.value.clone()];
+            // `read_cell` also honors STATE_RESULT_CELL if a builder aliases the
+            // hash argument to the ExprState result cell.
+            let (value, arg0_isnull) = crate::interp_loop::read_cell(state, *arg_cell);
+            let value = if arg0_isnull {
+                value
+            } else {
+                materialize_hashdatum_arg(mcx, finfo.fn_oid, value)?
+            };
+            let args = vec![value];
             // DatumGetUInt32(op->d.hashdatum.iresult->value) (NEXT32 only; the
             // FIRST variants ignore it). `iresult` carries the shared accumulator
             // cell id (C's aliased `iresult->value`); the prior column's hash
             // step wrote the running hash there, so read it back from that cell.
             let existing = (*iresult)
-                .map(|cell| state.result_cells.get(cell).value.as_u32())
+                .map(|cell| crate::interp_loop::read_cell(state, cell).0.as_u32())
                 .unwrap_or(0);
-            (finfo.fn_oid, fcinfo.fncollation, args, c.isnull, existing)
+            Ok((
+                finfo.fn_oid,
+                fcinfo.fncollation,
+                args,
+                arg0_isnull,
+                existing,
+            ))
         }
         other => unreachable!("EEOP_HASHDATUM_* carries the wrong payload: {other:?}"),
     }
+}
+
+/// Rebuild the legacy pointer-word representation of a by-reference hash key
+/// as the canonical owned byte image expected by `function_call_invoke_datum`.
+///
+/// `makeConst` still accepts C-shaped varlena pointer words at a sanctioned ABI
+/// edge. Most executor producers already emit `DatumV::ByRef`, but a folded or
+/// deserialized hash-key expression can therefore leave a non-NULL pointer word
+/// in the result cell. The fmgr canonical lane deliberately treats every
+/// `DatumV::ByVal` as a scalar, so forwarding that word would omit the referent
+/// and make `hashtext` fail to find `fcinfo.ref_args[0]`.
+///
+/// Limit recovery to PostgreSQL's built-in by-reference hash functions. Other
+/// hash procs retain their canonical value unchanged, and a missing payload then
+/// becomes the hash adapter's normal `PgResult` error rather than an unsafe guess
+/// about an extension-defined type.
+fn materialize_hashdatum_arg<'mcx>(
+    mcx: mcx::Mcx<'mcx>,
+    fn_oid: ::types_core::primitive::Oid,
+    value: DatumV<'mcx>,
+) -> PgResult<DatumV<'mcx>> {
+    // pg_proc.dat OIDs for hashname/hashtext/hashvarlena/hashbytea/
+    // hashoidvector and their extended variants.
+    const HASHNAME_OIDS: &[u32] = &[455, 447];
+    const HASHVARLENA_OIDS: &[u32] = &[400, 448, 456, 772, 6413, 6414, 457, 776];
+    const NAMEDATALEN: usize = 64;
+
+    let word = match value {
+        DatumV::ByVal(word) if HASHNAME_OIDS.contains(&fn_oid) => word,
+        DatumV::ByVal(word) if HASHVARLENA_OIDS.contains(&fn_oid) => word,
+        other => return Ok(other),
+    };
+    if word == 0 {
+        return Err(PgError::error(
+            "EEOP_HASHDATUM: non-NULL by-reference hash key has a null pointer",
+        ));
+    }
+
+    let ptr = word as *const u8;
+    if HASHNAME_OIDS.contains(&fn_oid) {
+        // SAFETY: this arm is reached only for hashname[_extended], whose
+        // non-NULL C Datum is a pointer to a NAMEDATALEN-byte NameData image.
+        let image = unsafe { core::slice::from_raw_parts(ptr, NAMEDATALEN) };
+        return Ok(DatumV::ByRef(mcx::slice_in(mcx, image)?));
+    }
+
+    // SAFETY: the remaining matched OIDs all accept a varlena pointer. The
+    // producer supplied a non-NULL pointer-word Datum under that hash proc's
+    // declared argument type, so reading its self-describing header and exactly
+    // the advertised image length mirrors C's VARSIZE_ANY(PointerGetDatum()).
+    let image = unsafe {
+        let header = ptr.read();
+        let len = if header == 0x01 {
+            // A bare external TOAST pointer should already have been detoasted
+            // by makeConst/slot deformation. Its tag-dependent span cannot be
+            // recovered here without reintroducing pointer-model TOAST state.
+            return Err(PgError::error(
+                "EEOP_HASHDATUM: external varlena hash key was not materialized",
+            ));
+        } else if (header & 0x01) == 0x01 {
+            ((header >> 1) & 0x7f) as usize
+        } else {
+            let raw = (ptr as *const u32).read_unaligned();
+            #[cfg(target_endian = "little")]
+            let len = ((raw >> 2) & 0x3fff_ffff) as usize;
+            #[cfg(target_endian = "big")]
+            let len = (raw & 0x3fff_ffff) as usize;
+            len
+        };
+        let min_header = if (header & 0x01) == 0x01 { 1 } else { 4 };
+        if len < min_header {
+            return Err(PgError::error(
+                "EEOP_HASHDATUM: malformed varlena hash-key image",
+            ));
+        }
+        core::slice::from_raw_parts(ptr, len)
+    };
+    // The fmgr dispatcher remains the single owner of compressed-varlena
+    // detoasting; this producer only restores the complete stored image.
+    Ok(DatumV::ByRef(mcx::slice_in(mcx, image)?))
 }
 
 /// Recover the `fn_expr` stamped onto an `EEOP_HASHDATUM_*` step's
@@ -686,9 +782,9 @@ pub fn exec_hashdatum_step<'mcx>(
     jumpdone: i32,
     estate: &EStateData<'mcx>,
 ) -> PgResult<usize> {
-    let (fn_oid, collation, args, arg0_isnull, existing) = hashdatum_step_inputs(state, op);
-    let (resvalue_id, _resnull_id) = res_cells(state, op);
     let mcx = estate.es_query_cxt;
+    let (fn_oid, collation, args, arg0_isnull, existing) = hashdatum_step_inputs(mcx, state, op)?;
+    let (resvalue_id, _resnull_id) = res_cells(state, op);
     let fn_expr = hashdatum_step_fn_expr(state, op);
 
     if first {
@@ -2159,4 +2255,39 @@ fn res_cells<'mcx>(
         .as_ref()
         .expect("eval_scalar: steps not ready")[op];
     (step.resvalue, step.resnull)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hashdatum_materializes_pointer_word_varlena_images() {
+        let ctx = ::mcx::MemoryContext::new("hashdatum materialize test");
+        let payload = b"hash join key";
+
+        let mut short = Vec::with_capacity(payload.len() + 1);
+        short.push((((payload.len() + 1) << 1) | 1) as u8);
+        short.extend_from_slice(payload);
+
+        let mut long = Vec::with_capacity(payload.len() + 4);
+        long.extend_from_slice(&::datum::varlena::set_varsize_4b(payload.len() + 4));
+        long.extend_from_slice(payload);
+
+        for image in [&short, &long] {
+            let value = DatumV::ByVal(image.as_ptr() as usize);
+            let materialized = materialize_hashdatum_arg(ctx.mcx(), 400, value).unwrap();
+            assert_eq!(materialized.as_ref_bytes(), image.as_slice());
+        }
+    }
+
+    #[test]
+    fn hashdatum_rejects_null_pointer_for_nonnull_byref_key() {
+        let ctx = ::mcx::MemoryContext::new("hashdatum null pointer test");
+        let err = materialize_hashdatum_arg(ctx.mcx(), 400, DatumV::ByVal(0)).unwrap_err();
+        assert_eq!(
+            err.message(),
+            "EEOP_HASHDATUM: non-NULL by-reference hash key has a null pointer"
+        );
+    }
 }


### PR DESCRIPTION
## Summary
Reproduce with the issue's exact MERGE query against a built pgrust, then trace which DatumV reaches `arg_bytes` without a varlena image. The hash-key gather lives in `hashdatum_step_inputs` / `exec_hashdatum_step` in `crates/backend/executor/execExprInterp/src/eval_scalar.rs`, which clones the evaluated key cell and dispatches through `function_call_invoke_datum`; the fix is to make the producer honor the documented invariant (carry the full by-ref image for the hash-key cell, materializing the referent bytes if the cell only holds a bare pointer word, as the codebase's own comments about the "bare-word `word_of` downgrade" describe), rather than papering over it in the consumer. If investigation shows the value legitimately cannot be materialized, degrade `arg_bytes` in `crates/backend/access/hashfunc/src/lib.rs` from a panic-style expect into a proper PgResult error as a secondary hardening.

## Why this matters
A SQLsmith-generated MERGE query (MERGE INTO information_schema.sql_sizing USING information_schema.parameters ON target.comments = ref.parameter_mode, with an all-NULL aclitem CASE in the WHEN MATCHED qual) raises `ERROR: hash fn: by-reference argument missing from the by-ref lane` on pgrust 18.3 but runs cleanly on PostgreSQL 18.3. The error string comes from `arg_bytes` in `crates/backend/access/hashfunc/src/lib.rs` (line ~383): the fmgr adapter for the type hash functions `.expect()`s that a by-reference argument (text/varchar here, via `hashtext`) arrives with its byte image on the fcinfo by-ref lane. The join key is a varchar column hashed by the planner-chosen hash join, so some producer feeds the EEOP_HASHDATUM step a Datum cell whose by-reference image was never materialized, violating the invariant the adapter asserts.

See https://github.com/malisper/pgrust/issues/22.

## Testing
- Happy path: the issue's MERGE query (hash join on text/varchar keys with NULL-heavy columns) executes without error and updates 0 rows, matching PostgreSQL 18.3 behavior. - Edge cases: hash join keys that are NULL (strict and non-strict EEOP_HASHDATUM variants), short-header (1-byte) varlena values, and multi-column hash keys exercising the NEXT32 combine path. - Error paths: unit test in crates/backend/access/hashfunc/src/tests.rs that a by-ref hash argument delivered without an image yields a clean PgResult error (or is impossible after the producer fix), not a process-level panic.

Fixes #22


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hash function handling for by-reference values, preventing panics when required data is missing.
  * Added support for both short and long varlena data layouts.
  * Improved hash evaluation compatibility with legacy by-reference value representations.
  * Added clearer errors for invalid or missing hash inputs.

* **Tests**
  * Added coverage for varlena layouts, missing arguments, and invalid pointer values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->