### PR TITLE
fix: stage by-ref numeric args in numrange_subdiff

### DIFF
--- a/crates/backend/utils/adt/adt_rangetypes/src/fmgr_builtins.rs
+++ b/crates/backend/utils/adt/adt_rangetypes/src/fmgr_builtins.rs
@@ -667,6 +667,36 @@ mod tests {
         assert!(call_range_pred(3850, &e1));
     }
 
+    /// `numrange_subdiff(numeric, numeric)` must stage by-reference element
+    /// args off the `ref_args` lane; reading the bare placeholder word faults
+    /// (issue #23: `SELECT numrange_subdiff(1,1)`).
+    #[test]
+    fn numrange_subdiff_stages_byref_numeric_args() {
+        install_test_typcache();
+        use numeric_seams as ns;
+        if !ns::numeric_subdiff::is_installed() {
+            ns::numeric_subdiff::set(|v1, v2| {
+                assert!(v1.as_usize() > 0xff, "v1 should be a staged pointer");
+                assert!(v2.as_usize() > 0xff, "v2 should be a staged pointer");
+                Ok(0.0)
+            });
+        }
+        register_rangetypes_builtins();
+        let mut fcinfo = FunctionCallInfoBaseData::new(None, 2, 0, None, None);
+        fcinfo.args = vec![
+            NullableDatum::value(Datum::null()),
+            NullableDatum::value(Datum::null()),
+        ];
+        let dummy = vec![0u8; 8];
+        fcinfo.ref_args = vec![
+            Some(RefPayload::Varlena(dummy.clone())),
+            Some(RefPayload::Varlena(dummy)),
+        ];
+        let native = fmgr_core::native_builtin(3924).expect("numrange_subdiff registered");
+        let result = native(&mut fcinfo).expect("numrange_subdiff ok");
+        assert_eq!(result.as_f64(), 0.0);
+    }
+
     /// Empty vs. finite: `range_eq` false, `range_cmp` orders empty first (C:
     /// an empty range sorts before any non-empty range, -1), `range_contains`
     /// (finite contains empty) true. All short-circuit on the EMPTY flag.

--- a/crates/backend/utils/adt/adt_rangetypes/src/range_fmgr_boundary.rs
+++ b/crates/backend/utils/adt/adt_rangetypes/src/range_fmgr_boundary.rs
@@ -937,11 +937,13 @@ pub fn int8range_subdiff<'mcx>(
 
 /// `numrange_subdiff(PG_FUNCTION_ARGS)` (rangetypes.c:1703).
 pub fn numrange_subdiff<'mcx>(
-    _mcx: Mcx<'mcx>,
+    mcx: Mcx<'mcx>,
     fcinfo: &mut FunctionCallInfoBaseData,
 ) -> PgResult<Datum> {
-    let v1 = getarg_datum(fcinfo, 0);
-    let v2 = getarg_datum(fcinfo, 1);
+    // `numeric` is by-reference: detoasted images cross on `ref_args`, not the
+    // bare placeholder word (see `stage_elem_arg`).
+    let v1 = stage_elem_arg(mcx, fcinfo, 0, false)?;
+    let v2 = stage_elem_arg(mcx, fcinfo, 1, false)?;
     Ok(float8_datum(crate::range_canonical_subdiff_hash::numrange_subdiff(v1, v2)?))
 }
 


### PR DESCRIPTION
Reading bare placeholder datum words for numeric arguments caused a segfault when calling numrange_subdiff with coerced integer literals. Fixes #23.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed numeric range calculations to correctly process by-reference numeric values.
  * Improved the reliability of numeric range difference operations when handling materialized numeric inputs.
  * Added regression coverage to prevent future issues with numeric argument handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->