### PR TITLE
Fix pg_get_expr for null node renderings

### DIFF
--- a/crates/backend/utils/adt/ruleutils/src/lib.rs
+++ b/crates/backend/utils/adt/ruleutils/src/lib.rs
@@ -3155,29 +3155,36 @@ fn pull_varnos_node<'mcx>(
 /// The shared body of `pg_get_expr` / `pg_get_expr_ext`: parse the
 /// `pg_node_tree` text into a node tree, reject querytrees and (depending on
 /// `relid`) expressions referencing relations we cannot deparse, build a
-/// one-relation deparse context if a relid was given, and deparse. Returns
-/// `Ok(None)` when the relation has gone away (C returns NULL).
+/// one-relation deparse context if a relid was given, and deparse. A null node
+/// rendering produces an empty string; `Ok(None)` is reserved for a relation
+/// that has gone away (C returns NULL).
 pub fn pg_get_expr_worker<'mcx>(
     mcx: Mcx<'mcx>,
     exprstr: &str,
     relid: Oid,
     pretty_flags: i32,
 ) -> PgResult<Option<PgString<'mcx>>> {
-    // Convert expression to node tree.
-    let node = read_seams::string_to_node::call(mcx, exprstr)?;
+    // Convert expression to node tree.  A top-level "<>" is C's NULL node,
+    // which is a valid rendering for catalog fields such as an unconditional
+    // pg_rewrite.ev_qual.
+    let node = read_seams::string_to_node_opt::call(mcx, exprstr)?;
 
     // Throw error if the input is a querytree rather than an expression tree.
     // Drill past surrounding Lists, then check for a Query.
-    if let Some(tst) = drill_past_lists(&node) {
-        if tst.node_tag() == ::nodes::nodes::ntag::T_Query {
-            return Err(PgError::error("input is a query, not an expression")
-                .with_sqlstate(::types_error::ERRCODE_INVALID_PARAMETER_VALUE));
+    if let Some(node) = node.as_deref() {
+        if let Some(tst) = drill_past_lists(node) {
+            if tst.node_tag() == ::nodes::nodes::ntag::T_Query {
+                return Err(PgError::error("input is a query, not an expression")
+                    .with_sqlstate(::types_error::ERRCODE_INVALID_PARAMETER_VALUE));
+            }
         }
     }
 
     // Throw error if the expression contains Vars we won't be able to deparse.
     let mut relids: Option<PgBox<'mcx, ::nodes::bitmapset::Bitmapset<'mcx>>> = None;
-    pull_varnos_node(mcx, &node, &mut relids)?;
+    if let Some(node) = node.as_deref() {
+        pull_varnos_node(mcx, node, &mut relids)?;
+    }
     if oid_is_valid(relid) {
         // !bms_is_subset(relids, bms_make_singleton(1))
         let ok = match relids.as_ref() {
@@ -3223,7 +3230,12 @@ pub fn pg_get_expr_worker<'mcx>(
     };
 
     // Deparse.
-    let str = deparse_expression_pretty(mcx, &node, context, false, false, pretty_flags, 0)?;
+    let str = match node.as_deref() {
+        Some(node) => {
+            deparse_expression_pretty(mcx, node, context, false, false, pretty_flags, 0)?
+        }
+        None => PgString::from_str_in("", mcx)?,
+    };
 
     Ok(Some(str))
 }

--- a/crates/backend/utils/adt/ruleutils/tests/pg_get_expr.rs
+++ b/crates/backend/utils/adt/ruleutils/tests/pg_get_expr.rs
@@ -1,0 +1,20 @@
+use ::mcx::MemoryContext;
+use ::types_core::primitive::Oid;
+
+#[test]
+fn accepts_null_node_rendering() {
+    read_seams::string_to_node_opt::set(nodes_core::read::string_to_node_opt);
+
+    let ctx = MemoryContext::new("pg_get_expr_null_node");
+    let result = ruleutils::pg_get_expr_worker(ctx.mcx(), "<>", Oid::default(), 0)
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(result.as_str(), "");
+
+    common_relation_seams::try_relation_open::set(|_mcx, _relid, _lockmode| Ok(None));
+    let missing_relation =
+        ruleutils::pg_get_expr_worker(ctx.mcx(), "<>", Oid::from(999_999_u32), 0).unwrap();
+
+    assert!(missing_relation.is_none());
+}


### PR DESCRIPTION
## Summary

- accept nullable node renderings in `pg_get_expr_worker`
- return an empty expression for a top-level `<>`, matching PostgreSQL
- preserve the existing SQL `NULL` result when the referenced relation is missing
- add focused regression coverage for both cases

## Root cause

`pg_get_expr_worker` used the non-null `string_to_node` seam. PostgreSQL allows `stringToNode` to return a null node for a top-level `<>`, and its expression deparser emits an empty string for that input. Treating the null node as malformed caused the reported internal error.

## Testing

- `cargo test --locked -p ruleutils --test pg_get_expr`
- `cargo check --locked --profile fast-check --bin postgres`

Fixes #18
