### PR TITLE
Propagate core errors and add reliability CI

### DIFF
--- a/.github/workflows/core-ci.yml
+++ b/.github/workflows/core-ci.yml
@@ -1,0 +1,33 @@
+name: Core CI
+
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: core-ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  core:
+    name: Server build and core tests
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    env:
+      CARGO_TERM_COLOR: always
+      CARGO_TARGET_DIR: target
+    steps:
+      - name: Check out source
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - name: Install native build dependencies
+        run: sudo apt-get update && sudo apt-get install --yes libre2-dev pkg-config
+
+      - name: Install pinned Rust toolchain
+        run: rustup show active-toolchain
+
+      - name: Run core quality gate
+        run: bash scripts/check-core.sh

--- a/.github/workflows/core-ci.yml
+++ b/.github/workflows/core-ci.yml
@@ -22,6 +22,8 @@ jobs:
     steps:
       - name: Check out source
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
 
       - name: Install native build dependencies
         run: sudo apt-get update && sudo apt-get install --yes libre2-dev pkg-config

--- a/crates/backend/access/index/indexam/src/lib.rs
+++ b/crates/backend/access/index/indexam/src/lib.rs
@@ -276,6 +276,9 @@ pub fn index_bulk_delete_collect<'mcx>(
         // brinbulkdelete never invokes the callback: BRIN has no
         // per-heap-tuple entries to report.
         IndexAmKind::Brin => Ok(IndexBulkDeleteResult::default()),
+        // `Mock` exists only when the dependency's test feature is unified;
+        // in a production build every variant above is exhaustive.
+        #[allow(unreachable_patterns)]
         _ => panic!("unported: ambulkdelete TID-collect beyond btree/hash/gin/gist/spgist/brin (validate_index)"),
     }
 }

--- a/crates/backend/access/spgist/spgist/src/doinsert.rs
+++ b/crates/backend/access/spgist/spgist/src/doinsert.rs
@@ -1547,7 +1547,7 @@ pub fn spgdoinsert<'m>(
         } else if current.blkno != parent.blkno {
             current.buffer = bufmgr::read_buffer::call(index, current.blkno)?;
             if !bufmgr::conditional_lock_buffer::call(current.buffer)? {
-                bufmgr::release_buffer::call(current.buffer);
+                bufmgr::release_buffer::call(current.buffer)?;
                 unlock_release(parent.buffer)?;
                 return Ok(false);
             }

--- a/crates/backend/access/spgist/spgist/src/doinsert.rs
+++ b/crates/backend/access/spgist/spgist/src/doinsert.rs
@@ -1547,8 +1547,10 @@ pub fn spgdoinsert<'m>(
         } else if current.blkno != parent.blkno {
             current.buffer = bufmgr::read_buffer::call(index, current.blkno)?;
             if !bufmgr::conditional_lock_buffer::call(current.buffer)? {
-                bufmgr::release_buffer::call(current.buffer)?;
-                unlock_release(parent.buffer)?;
+                let current_release = bufmgr::release_buffer::call(current.buffer);
+                let parent_release = unlock_release(parent.buffer);
+                current_release?;
+                parent_release?;
                 return Ok(false);
             }
         } else {

--- a/crates/backend/access/spgist/spgist/src/utils.rs
+++ b/crates/backend/access/spgist/spgist/src/utils.rs
@@ -38,7 +38,7 @@ pub fn relation_needs_wal(rel: &Relation<'_>) -> bool {
 
 pub fn unlock_release(buffer: Buffer) -> PgResult<()> {
     bufmgr::lock_buffer::call(buffer, bufmgr::BUFFER_LOCK_UNLOCK)?;
-    bufmgr::release_buffer::call(buffer);
+    bufmgr::release_buffer::call(buffer)?;
     Ok(())
 }
 
@@ -349,7 +349,7 @@ pub fn SpGistNewBuffer(index: &Relation<'_>) -> PgResult<Buffer> {
             }
             bufmgr::lock_buffer::call(buffer, bufmgr::BUFFER_LOCK_UNLOCK)?;
         }
-        bufmgr::release_buffer::call(buffer);
+        bufmgr::release_buffer::call(buffer)?;
     }
 
     let (buf, _extended_by) = bufmgr::extend_buffered_rel_by::call(
@@ -383,7 +383,7 @@ pub fn SpGistUpdateMetaPage(index: &Relation<'_>) -> PgResult<()> {
         bufmgr::mark_buffer_dirty::call(metabuffer)?;
         unlock_release(metabuffer)?;
     } else {
-        bufmgr::release_buffer::call(metabuffer);
+        bufmgr::release_buffer::call(metabuffer)?;
     }
     Ok(())
 }
@@ -469,7 +469,7 @@ pub fn SpGistGetBuffer(
         let buffer = bufmgr::read_buffer::call(index, blkno)?;
 
         if !bufmgr::conditional_lock_buffer::call(buffer)? {
-            bufmgr::release_buffer::call(buffer);
+            bufmgr::release_buffer::call(buffer)?;
             *is_new = true;
             let nb = allocNewBuffer(index, flags, &mut cache)?;
             set_cache(index, cache);

--- a/crates/backend/catalog/catalog_dependency/src/find_expr.rs
+++ b/crates/backend/catalog/catalog_dependency/src/find_expr.rs
@@ -603,15 +603,6 @@ fn walker<'w, 'mcx: 'w>(
             Some(e) => walker(e, context),
             None => Ok(()),
         },
-        NodeTag::T_CoerceViaIO => {
-            let io = node.as_coerce_via_io().unwrap();
-            // No exposed function; depend on the type (and collation).
-            context.add(TYPE_RELATION_ID, io.resulttype, 0);
-            if io.resultcollid != InvalidOid && io.resultcollid != DEFAULT_COLLATION_OID {
-                context.add(CollationRelationId, io.resultcollid, 0);
-            }
-            walker(io.arg, context)
-        }
         NodeTag::T_JsonExpr => {
             let j = node.as_json_expr().unwrap();
             for e in [j.formatted_expr, j.path_spec, j.on_empty, j.on_error]

--- a/crates/backend/catalog/objectaddress/src/lib.rs
+++ b/crates/backend/catalog/objectaddress/src/lib.rs
@@ -1627,11 +1627,6 @@ pub fn check_object_ownership<'mcx>(
                 aclchk::aclcheck_error(aclchk::ACLCHECK_NOT_OWNER, objtype, name)?;
             }
         }
-        ObjectType::OBJECT_TYPE | ObjectType::OBJECT_DOMAIN | ObjectType::OBJECT_ATTRIBUTE => {
-            if !aclchk::object_ownercheck(address.classId, address.objectId, roleid)? {
-                aclcheck_error_type(aclchk::ACLCHECK_NOT_OWNER, address.objectId)?;
-            }
-        }
         other => panic!("check_object_ownership: unsupported object type: {other:?}"),
     }
     Ok(())

--- a/crates/backend/commands/tablecmds/src/alter.rs
+++ b/crates/backend/commands/tablecmds/src/alter.rs
@@ -166,8 +166,6 @@ pub fn AlterTableGetLockLevel(cmds: &NodeList<'_>) -> LOCKMODE {
             | AlterTableType::AT_SetAccessMethod
             | AlterTableType::AT_ChangeOwner
             | AlterTableType::AT_GenericOptions => AccessExclusiveLock,
-            AlterTableType::AT_AddColumnToView
-            | AlterTableType::AT_ReplaceRelOptions => AccessExclusiveLock,
             other => panic!("unrecognized alter table type: {}", other as i32),
         };
         if cmd_lockmode > lockmode {

--- a/crates/backend/executor/execexpr/src/compile.rs
+++ b/crates/backend/executor/execexpr/src/compile.rs
@@ -2149,7 +2149,6 @@ pub(crate) fn init_expr_rec<'mcx>(
             }
             init_subplan_expr(node, state, mcx, out, agg, params, sub)
         }
-        NodeTag::T_BoolExpr => init_bool_expr(node, state, mcx, out, agg, params, sub),
         NodeTag::T_CaseExpr => init_case_expr(node, state, mcx, out, agg, params, sub),
         NodeTag::T_CaseTestExpr => match state.innermost_case {
             Some(slot) => push_step(state, mcx, Step::CaseTestVal { slot, out }),

--- a/crates/backend/executor/execexpr/src/interp.rs
+++ b/crates/backend/executor/execexpr/src/interp.rs
@@ -3561,7 +3561,6 @@ fn eval_row_compare_final(cmptype: i32, cmpresult: i32) -> bool {
 // #[inline(always)] keeps run_program's codegen identical to the previous
 // inline form (the interpreter is instruction-count-gated).
 
-#[inline(always)]
 // NULLIF: null-or-unequal keeps arg0; strict equality only when both
 // non-null (C ExecEvalFuncExpr + NULLIF special case semantics, shared by
 // run_program and the JIT single-step tier).

--- a/crates/backend/executor/execmain/src/execami.rs
+++ b/crates/backend/executor/execmain/src/execami.rs
@@ -97,8 +97,7 @@ pub fn exec_re_scan<'mcx>(
         }
         PlanStateNode::CteScan(cs) => ::nodectescan::exec_rescan_cte_scan(cs, estate),
         PlanStateNode::WorkTableScan(wts) => {
-            ::nodeworktablescan::exec_rescan_work_table_scan(wts, estate);
-            Ok(())
+            ::nodeworktablescan::exec_rescan_work_table_scan(wts, estate)
         }
         PlanStateNode::NamedTuplestoreScan(nts) => {
             ::nodenamedtuplestorescan::exec_rescan_named_tuplestore_scan(nts, estate)
@@ -477,7 +476,7 @@ pub(crate) fn exec_re_scan_chg_forced<'mcx>(
             ::nodectescan::exec_rescan_cte_scan_chg(cs, estate, chg)?
         }
         PlanStateNode::WorkTableScan(wts) => {
-            ::nodeworktablescan::exec_rescan_work_table_scan(wts, estate)
+            ::nodeworktablescan::exec_rescan_work_table_scan(wts, estate)?
         }
         PlanStateNode::NamedTuplestoreScan(nts) => {
             ::nodenamedtuplestorescan::exec_rescan_named_tuplestore_scan(nts, estate)?;

--- a/crates/backend/executor/nodeagg/src/gsets.rs
+++ b/crates/backend/executor/nodeagg/src/gsets.rs
@@ -588,10 +588,10 @@ fn init_hash_sets<'mcx>(
         let mut aggrefs: PgVec<'mcx, (Node<'mcx>, &'mcx types_nodes::primnodes::Aggref<'mcx>)> =
             PgVec::new_in(mcx);
         for tle in node.plan.targetlist.iter() {
-            crate::collect_aggrefs(tle, &mut aggrefs);
+            crate::collect_aggrefs(tle, &mut aggrefs)?;
         }
         for q in node.plan.qual.iter() {
-            crate::collect_aggrefs(q, &mut aggrefs);
+            crate::collect_aggrefs(q, &mut aggrefs)?;
         }
         for &(_, aggref) in aggrefs.iter() {
             for a in aggref.args.iter() {

--- a/crates/backend/executor/nodefunctionscan/src/lib.rs
+++ b/crates/backend/executor/nodefunctionscan/src/lib.rs
@@ -124,7 +124,7 @@ impl<'mcx> ScanNode<'mcx> for FunctionScanState<'mcx> {
                     // during the scan (dropped only by the estate reset cb).
                     unsafe { self.arg_mcx.as_mut() },
                 )?;
-                store.rescan();
+                store.rescan()?;
                 fs.tstore = Some(store);
             }
             let fs = &mut self.funcstates[0];
@@ -158,7 +158,7 @@ impl<'mcx> ScanNode<'mcx> for FunctionScanState<'mcx> {
                     // during the scan (dropped only by the estate reset cb).
                     unsafe { self.arg_mcx.as_mut() },
                 )?;
-                store.rescan();
+                store.rescan()?;
                 fs.tstore = Some(store);
             }
             let fs = &mut self.funcstates[funcno];
@@ -876,7 +876,7 @@ pub fn exec_rescan_function_scan<'mcx>(
     node.ordinal = 0;
     for fs in node.funcstates.iter_mut() {
         if let Some(store) = fs.tstore.as_mut() {
-            store.rescan();
+            store.rescan()?;
         }
     }
     Ok(())
@@ -903,7 +903,7 @@ pub fn exec_rescan_function_scan_chg<'mcx>(
             }
             fs.rowcount = -1;
         } else if let Some(store) = fs.tstore.as_mut() {
-            store.rescan();
+            store.rescan()?;
         }
     }
     Ok(())

--- a/crates/backend/executor/nodetablefuncscan/src/lib.rs
+++ b/crates/backend/executor/nodetablefuncscan/src/lib.rs
@@ -209,7 +209,7 @@ impl<'mcx> TableFuncScanState<'mcx> {
             r?;
         }
 
-        store.rescan();
+        store.rescan()?;
         self.tstore = Some(store);
         Ok(())
     }
@@ -515,7 +515,7 @@ pub fn exec_rescan_table_func_scan<'mcx>(
 ) -> PgResult<()> {
     execscan::exec_scan_rescan(&mut node.ss, estate);
     if let Some(store) = node.tstore.as_mut() {
-        store.rescan();
+        store.rescan()?;
     }
     Ok(())
 }

--- a/crates/backend/executor/nodeworktablescan/src/lib.rs
+++ b/crates/backend/executor/nodeworktablescan/src/lib.rs
@@ -133,14 +133,15 @@ pub fn exec_init_work_table_scan<'mcx>(
 pub fn exec_rescan_work_table_scan<'mcx>(
     node: &mut WorkTableScanState<'mcx>,
     estate: &mut EStateData<'mcx>,
-) {
+) -> PgResult<()> {
     execscan::exec_scan_rescan(&mut node.ss, estate);
     if node.rustate_resolved {
         let param = node.plan.wtParam as usize;
         if let Some(shared) = estate.worktable_shared_slot(param).as_mut() {
-            shared.working_table.rescan();
+            shared.working_table.rescan()?;
         }
     }
+    Ok(())
 }
 
 mcx::forget_safe_struct!(

--- a/crates/backend/nodes/nodes_core/src/node_funcs.rs
+++ b/crates/backend/nodes/nodes_core/src/node_funcs.rs
@@ -44,7 +44,6 @@ pub fn expr_type(node: Node<'_>) -> Oid {
         NodeTag::T_CoerceToDomain => node.as_coerce_to_domain().unwrap().resulttype,
         NodeTag::T_CoerceToDomainValue => node.as_coerce_to_domain_value().unwrap().typeId,
         NodeTag::T_SetToDefault => node.as_set_to_default().unwrap().typeId,
-        NodeTag::T_CollateExpr => expr_type(node.as_collate_expr().unwrap().arg),
         NodeTag::T_SQLValueFunction => node.as_sql_value_function().unwrap().r#type,
         NodeTag::T_SubscriptingRef => node.as_subscripting_ref().unwrap().refrestype,
         NodeTag::T_CaseTestExpr => node.as_case_test_expr().unwrap().typeId,
@@ -191,7 +190,6 @@ pub fn expr_typmod(node: Node<'_>) -> i32 {
         | NodeTag::T_FieldStore
         | NodeTag::T_RowCompareExpr
         | NodeTag::T_RowExpr => -1,
-        NodeTag::T_CollateExpr => expr_typmod(node.as_collate_expr().unwrap().arg),
         NodeTag::T_SQLValueFunction => node.as_sql_value_function().unwrap().typmod,
         NodeTag::T_CaseExpr => {
             let c = node.as_case_expr().unwrap();
@@ -293,7 +291,6 @@ pub fn expr_collation(node: Node<'_>) -> Oid {
         NodeTag::T_CoerceToDomain => node.as_coerce_to_domain().unwrap().resultcollid,
         NodeTag::T_CoerceToDomainValue => node.as_coerce_to_domain_value().unwrap().collation,
         NodeTag::T_SetToDefault => node.as_set_to_default().unwrap().collation,
-        NodeTag::T_CollateExpr => node.as_collate_expr().unwrap().collOid,
         NodeTag::T_SubscriptingRef => node.as_subscripting_ref().unwrap().refcollid,
         NodeTag::T_CaseTestExpr => node.as_case_test_expr().unwrap().collation,
         NodeTag::T_SQLValueFunction => {
@@ -473,7 +470,6 @@ pub fn expr_location(node: Node<'_>) -> ParseLoc {
             leftmost_loc(c.location, expr_location(c.arg))
         }
         NodeTag::T_CoerceToDomainValue => node.as_coerce_to_domain_value().unwrap().location,
-        NodeTag::T_CollateExpr => expr_location(node.as_collate_expr().unwrap().arg),
         NodeTag::T_SQLValueFunction => node.as_sql_value_function().unwrap().location,
         NodeTag::T_CaseTestExpr => -1,
         // C: the CASE/WHEN/COALESCE/GREATEST/LEAST keyword is always leftmost.

--- a/crates/backend/nodes/outfuncs/src/lib.rs
+++ b/crates/backend/nodes/outfuncs/src/lib.rs
@@ -14,7 +14,7 @@ use types_error::PgResult;
 use types_nodes::bitmapset::Bitmapset;
 use types_nodes::list::{IntList, NodeList, OidList, OptNodeList};
 use types_nodes::parsenodes::{
-    CommonTableExpr, Query, RTEKind, RTEPermissionInfo, RangeTblEntry, SetOperationStmt,
+    CommonTableExpr, Query, RTEKind, RTEPermissionInfo, RangeTblEntry,
     SortGroupClause, TableSampleClause,
 };
 use types_nodes::primnodes::{
@@ -519,24 +519,6 @@ fn out_node(out: &mut PgString<'_>, node: Node<'_>) -> PgResult<()> {
             out_opt_node(out, sr.refassgnexpr)?;
             w!(out, "}}");
         }
-        NodeTag::T_CaseExpr => {
-            let c = node.as_variant::<types_nodes::primnodes::CaseExpr>().expect("CaseExpr");
-            w!(out, "{{CASEEXPR :casetype {} :casecollid {} :arg ", c.casetype, c.casecollid);
-            out_opt_node(out, c.arg)?;
-            w!(out, " :args ");
-            out_list(out, &c.args)?;
-            w!(out, " :defresult ");
-            out_opt_node(out, c.defresult)?;
-            w!(out, " :location -1}}");
-        }
-        NodeTag::T_CaseWhen => {
-            let cw = node.as_variant::<types_nodes::primnodes::CaseWhen>().expect("CaseWhen");
-            w!(out, "{{CASEWHEN :expr ");
-            out_opt_node(out, cw.expr)?;
-            w!(out, " :result ");
-            out_opt_node(out, cw.result)?;
-            w!(out, " :location -1}}");
-        }
         NodeTag::T_CollateExpr => {
             let c = node
                 .as_variant::<types_nodes::primnodes::CollateExpr>()
@@ -583,43 +565,6 @@ fn out_node(out: &mut PgString<'_>, node: Node<'_>) -> PgResult<()> {
             );
             out_list(out, &m.args)?;
             w!(out, " :location -1}}");
-        }
-        NodeTag::T_WindowFunc => {
-            let f =
-                node.as_variant::<types_nodes::primnodes::WindowFunc>().expect("WindowFunc");
-            w!(
-                out,
-                "{{WINDOWFUNC :winfnoid {} :wintype {} :wincollid {} :inputcollid {} :args ",
-                f.winfnoid, f.wintype, f.wincollid, f.inputcollid
-            );
-            out_list(out, &f.args)?;
-            w!(out, " :aggfilter ");
-            out_opt_node(out, f.aggfilter)?;
-            w!(out, " :runCondition ");
-            out_list(out, &f.runCondition)?;
-            w!(out, " :winref {} :winstar ", f.winref);
-            out_bool(out, f.winstar);
-            w!(out, " :winagg ");
-            out_bool(out, f.winagg);
-            w!(out, " :location -1}}");
-        }
-        NodeTag::T_SetOperationStmt => {
-            let s = node.as_variant::<SetOperationStmt>().expect("SetOperationStmt");
-            w!(out, "{{SETOPERATIONSTMT :op {} :all ", s.op as u32);
-            out_bool(out, s.all);
-            w!(out, " :larg ");
-            out_opt_node(out, s.larg)?;
-            w!(out, " :rarg ");
-            out_opt_node(out, s.rarg)?;
-            w!(out, " :colTypes ");
-            out_oid_list(out, &s.colTypes);
-            w!(out, " :colTypmods ");
-            out_int_list(out, &s.colTypmods);
-            w!(out, " :colCollations ");
-            out_oid_list(out, &s.colCollations);
-            w!(out, " :groupClauses ");
-            out_list(out, &s.groupClauses)?;
-            w!(out, "}}");
         }
         NodeTag::T_CurrentOfExpr => {
             let c = node
@@ -722,16 +667,6 @@ fn out_node(out: &mut PgString<'_>, node: Node<'_>) -> PgResult<()> {
                 .expect("AlternativeSubPlan");
             w!(out, "{{ALTERNATIVESUBPLAN :subplans ");
             out_list(out, &a.subplans)?;
-            w!(out, "}}");
-        }
-        NodeTag::T_NotifyStmt => {
-            let n = node
-                .as_variant::<types_nodes::parsenodes::NotifyStmt>()
-                .expect("NotifyStmt");
-            w!(out, "{{NOTIFYSTMT :conditionname ");
-            out_str(out, n.conditionname);
-            w!(out, " :payload ");
-            out_str(out, n.payload);
             w!(out, "}}");
         }
         NodeTag::T_WithCheckOption => {

--- a/crates/backend/optimizer/plan/planner/src/cte.rs
+++ b/crates/backend/optimizer/plan/planner/src/cte.rs
@@ -94,7 +94,7 @@ pub fn ss_process_ctes<'mcx>(run: &mut PlannerRun<'mcx>, parse: &Query<'mcx>) ->
             startup_cost: 0.0,
             per_call_cost: 0.0,
         };
-        crate::subselect::cost_subplan(&mut splan, plan);
+        crate::subselect::cost_subplan(&mut splan, plan)?;
         let splan_node = Node::mk(mcx, splan)?;
         let splan_id = run.intern_expr(splan_node);
         run.root.init_plans.push(splan_id);

--- a/crates/backend/optimizer/plan/planner/src/selfuncs.rs
+++ b/crates/backend/optimizer/plan/planner/src/selfuncs.rs
@@ -2617,7 +2617,6 @@ fn btcostestimate(
                     }
                     0
                 }
-                NodeTag::T_RowCompareExpr => clause.as_row_compare_expr().unwrap().opnos.nth(0),
                 other => panic!("btcostestimate (selfuncs.c): indexqual {other:?}; M2 lane"),
             };
             if clause_op != 0 {

--- a/crates/backend/optimizer/plan/planner/src/subselect.rs
+++ b/crates/backend/optimizer/plan/planner/src/subselect.rs
@@ -2450,7 +2450,7 @@ pub(crate) fn ss_make_initplan_from_plan<'mcx>(
         startup_cost: 0.0,
         per_call_cost: 0.0,
     };
-    cost_subplan(&mut splan, plan);
+    cost_subplan(&mut splan, plan)?;
     let splan_id = run.intern_expr(Node::mk(mcx, splan)?);
     run.root.init_plans.push(splan_id);
     Ok(())

--- a/crates/backend/optimizer/util/clauses/src/fold.rs
+++ b/crates/backend/optimizer/util/clauses/src/fold.rs
@@ -437,20 +437,6 @@ fn ece_mutator<'mcx>(node: Node<'mcx>, cx: &EceContext<'mcx>) -> PgResult<Option
                 }
             }
         }
-        NodeTag::T_RelabelType => {
-            let r = node.as_relabel_type().unwrap();
-            let arg = ece_mutator(r.arg, cx)?.unwrap_or(r.arg);
-            apply_relabel_type(
-                cx.mcx,
-                arg,
-                r.resulttype,
-                r.resulttypmod,
-                r.resultcollid,
-                r.relabelformat,
-                r.location,
-            )
-            .map(Some)
-        }
         // C: CollateExpr is replaced with an equivalent RelabelType.
         NodeTag::T_CollateExpr => {
             let c = node.as_collate_expr().unwrap();
@@ -761,77 +747,6 @@ fn ece_mutator<'mcx>(node: Node<'mcx>, cx: &EceContext<'mcx>) -> PgResult<Option
                     mm.minmaxcollid,
                 )
                 .map(Some);
-            }
-            Ok(new)
-        }
-        NodeTag::T_ArrayExpr => {
-            let new = expression_tree_mutator(cx.mcx, node, &mut |n| ece_mutator(n, cx))?;
-            let eff = new.unwrap_or(node);
-            if all_arguments_const(eff)? {
-                let a = eff.as_array_expr().unwrap();
-                return clauses_seams::evaluate_expr::call(
-                    cx.mcx,
-                    eff,
-                    a.array_typeid,
-                    -1,
-                    a.array_collid,
-                )
-                .map(Some);
-            }
-            Ok(new)
-        }
-        NodeTag::T_ScalarArrayOpExpr => {
-            let new = expression_tree_mutator(cx.mcx, node, &mut |n| ece_mutator(n, cx))?;
-            let eff = new.unwrap_or(node);
-            let sa = eff.as_scalar_array_op_expr().unwrap();
-            // set_sa_opfuncid, without C's memo write-back (walker.rs).
-            let opfuncid =
-                if sa.opfuncid == 0 { lsyscache::get_opcode(sa.opno)? } else { sa.opfuncid };
-            // ece_function_is_safe: non-volatile folds (estimation lane off).
-            const PROVOLATILE_VOLATILE: i8 = b'v' as i8;
-            if lsyscache::func_volatile(opfuncid)? != PROVOLATILE_VOLATILE
-                && all_arguments_const(eff)?
-            {
-                let refolded = if opfuncid != sa.opfuncid || new.is_none() {
-                    Node::mk(
-                        cx.mcx,
-                        types_nodes::ScalarArrayOpExpr {
-                            opno: sa.opno,
-                            opfuncid,
-                            hashfuncid: sa.hashfuncid,
-                            negfuncid: sa.negfuncid,
-                            useOr: sa.useOr,
-                            inputcollid: sa.inputcollid,
-                            args: sa.args.clone_in(cx.mcx)?,
-                            location: sa.location,
-                        },
-                    )?
-                } else {
-                    eff
-                };
-                return clauses_seams::evaluate_expr::call(
-                    cx.mcx,
-                    refolded,
-                    types_core::catalog::BOOLOID,
-                    -1,
-                    InvalidOid,
-                )
-                .map(Some);
-            }
-            if opfuncid != sa.opfuncid {
-                return Ok(Some(Node::mk(
-                    cx.mcx,
-                    types_nodes::ScalarArrayOpExpr {
-                        opno: sa.opno,
-                        opfuncid,
-                        hashfuncid: sa.hashfuncid,
-                        negfuncid: sa.negfuncid,
-                        useOr: sa.useOr,
-                        inputcollid: sa.inputcollid,
-                        args: sa.args.clone_in(cx.mcx)?,
-                        location: sa.location,
-                    },
-                )?));
             }
             Ok(new)
         }

--- a/crates/backend/parser/coerce/src/lib.rs
+++ b/crates/backend/parser/coerce/src/lib.rs
@@ -2199,7 +2199,6 @@ pub fn expression_returns_set(node: Node<'_>) -> bool {
         | NodeTag::T_Param
         | NodeTag::T_Var
         | NodeTag::T_CaseTestExpr
-        | NodeTag::T_SQLValueFunction
         | NodeTag::T_CurrentOfExpr
         | NodeTag::T_MergeSupportFunc
         | NodeTag::T_CoerceToDomainValue => false,
@@ -2233,12 +2232,6 @@ pub fn expression_returns_set(node: Node<'_>) -> bool {
         // expression_tree_walker (nodeFuncs.c:2257-2258).
         NodeTag::T_AlternativeSubPlan => {
             node.as_alternative_sub_plan().unwrap().subplans.iter().any(expression_returns_set)
-        }
-        NodeTag::T_ScalarArrayOpExpr => {
-            node.as_scalar_array_op_expr().unwrap().args.iter().any(expression_returns_set)
-        }
-        NodeTag::T_ArrayExpr => {
-            node.as_array_expr().unwrap().elements.iter().any(expression_returns_set)
         }
         NodeTag::T_SubscriptingRef => {
             let sr = node.as_subscripting_ref().unwrap();

--- a/crates/backend/parser/parse_collate/src/lib.rs
+++ b/crates/backend/parser/parse_collate/src/lib.rs
@@ -357,16 +357,6 @@ fn assign_collations_walker<'mcx>(
             };
             location = expr_location(node);
         }
-        // COLLATE sets an explicitly derived collation regardless of the
-        // child state; still recurse to set up collation info below.
-        NodeTag::T_CollateExpr => {
-            let ce = node.as_collate_expr().unwrap();
-            assign_collations_walker(ce.arg, &mut loccontext)?;
-            collation = ce.collOid;
-            debug_assert!(OidIsValid(collation));
-            strength = CollateStrength::Explicit;
-            location = ce.location;
-        }
         // C's default arm over the closed set this lane can produce.
         // SubLink: children walked (T_Query arm supplies the EXPR sublink's
         // first-column collation); exprSetCollation on SubLink is a C no-op.
@@ -390,9 +380,6 @@ fn assign_collations_walker<'mcx>(
         | NodeTag::T_NullTest
         | NodeTag::T_BooleanTest
         | NodeTag::T_DistinctExpr
-        | NodeTag::T_ScalarArrayOpExpr
-        | NodeTag::T_ArrayExpr
-        | NodeTag::T_SQLValueFunction
         | NodeTag::T_JsonValueExpr
         | NodeTag::T_JsonConstructorExpr
         | NodeTag::T_JsonIsPredicate
@@ -402,8 +389,7 @@ fn assign_collations_walker<'mcx>(
         | NodeTag::T_XmlExpr
         | NodeTag::T_SubscriptingRef
         | NodeTag::T_FieldStore
-        | NodeTag::T_MergeSupportFunc
-        | NodeTag::T_NamedArgExpr) => {
+        | NodeTag::T_MergeSupportFunc) => {
             match tag {
                 // C: never recurse into the CASE test expression — it was
                 // collation-marked in transformCaseExpr and doesn't affect
@@ -593,24 +579,7 @@ fn assign_collations_walker<'mcx>(
                         assign_collations_walker(e, &mut loccontext)?;
                     }
                 }
-                NodeTag::T_ScalarArrayOpExpr => {
-                    for arg in &node.as_scalar_array_op_expr().unwrap().args {
-                        assign_collations_walker(arg, &mut loccontext)?;
-                    }
-                }
-                NodeTag::T_ArrayExpr => {
-                    for el in &node.as_array_expr().unwrap().elements {
-                        assign_collations_walker(el, &mut loccontext)?;
-                    }
-                }
-                NodeTag::T_SQLValueFunction => {}
                 NodeTag::T_MergeSupportFunc => {}
-                NodeTag::T_NamedArgExpr => {
-                    assign_collations_walker(
-                        node.as_named_arg_expr().unwrap().arg.expect("NamedArgExpr has an arg"),
-                        &mut loccontext,
-                    )?;
-                }
                 NodeTag::T_JsonValueExpr => {
                     let j = node.as_json_value_expr().unwrap();
                     if let Some(e) = j.raw_expr {
@@ -793,25 +762,8 @@ fn assign_collations_walker<'mcx>(
                         .unwrap(),
                     // exprSetCollation(SubLink) is assert-only in C.
                     NodeTag::T_SubLink => {}
-                    // exprSetCollation(NamedArgExpr) is assert-only in C
-                    // (collation == exprCollation(arg)).
-                    NodeTag::T_NamedArgExpr => {
-                        debug_assert_eq!(set_coll, expr_collation(node));
-                    }
                     NodeTag::T_SubscriptingRef => node
                         .with_mut::<types_nodes::SubscriptingRef, _>(|s| s.refcollid = set_coll)
-                        .unwrap(),
-                    // exprSetCollation(ScalarArrayOpExpr) is assert-only
-                    // (boolean result); only inputcollid is written.
-                    NodeTag::T_ScalarArrayOpExpr => {
-                        debug_assert!(!OidIsValid(set_coll));
-                        node.with_mut::<types_nodes::ScalarArrayOpExpr, _>(|s| {
-                            s.inputcollid = input_coll;
-                        })
-                        .unwrap()
-                    }
-                    NodeTag::T_ArrayExpr => node
-                        .with_mut::<types_nodes::ArrayExpr, _>(|a| a.array_collid = set_coll)
                         .unwrap(),
                     // exprSetCollation(XmlExpr) is assert-only: the text
                     // result (IS_XMLSERIALIZE) carries DEFAULT_COLLATION_OID,
@@ -822,17 +774,6 @@ fn assign_collations_walker<'mcx>(
                                 == types_nodes::XmlExprOp::IS_XMLSERIALIZE
                             {
                                 set_coll == types_core::catalog::DEFAULT_COLLATION_OID
-                            } else {
-                                !OidIsValid(set_coll)
-                            }
-                        );
-                    }
-                    NodeTag::T_SQLValueFunction => {
-                        debug_assert!(
-                            if node.as_sql_value_function().unwrap().r#type
-                                == types_core::catalog::NAMEOID
-                            {
-                                set_coll == types_core::catalog::C_COLLATION_OID
                             } else {
                                 !OidIsValid(set_coll)
                             }

--- a/crates/backend/parser/parse_expr/src/lib.rs
+++ b/crates/backend/parser/parse_expr/src/lib.rs
@@ -114,20 +114,6 @@ pub fn transformExprRecurse<'mcx>(
         }
         NodeTag::T_MultiAssignRef => transformMultiAssignRef(mcx, pstate, expr),
         NodeTag::T_FuncCall => transformFuncCall(mcx, pstate, expr),
-        // C mutates na->arg in place; sealed nodes rebuild the wrapper.
-        NodeTag::T_NamedArgExpr => {
-            let na = expr.as_named_arg_expr().unwrap();
-            let arg = transformExprRecurse(mcx, pstate, na.arg.expect("NamedArgExpr has an arg"))?;
-            Node::mk(
-                mcx,
-                types_nodes::NamedArgExpr {
-                    arg: Some(arg),
-                    name: na.name,
-                    argnumber: na.argnumber,
-                    location: na.location,
-                },
-            )
-        }
         NodeTag::T_SubLink => transformSubLink(mcx, pstate, expr),
         NodeTag::T_NullTest => transformNullTest(mcx, pstate, expr),
         NodeTag::T_GroupingFunc => parse_agg::transformGroupingFunc(

--- a/crates/backend/parser/parse_target/src/lib.rs
+++ b/crates/backend/parser/parse_target/src/lib.rs
@@ -1381,23 +1381,6 @@ fn FigureColnameInternal<'mcx>(node: Node<'mcx>, name: &mut Option<&'mcx str>) -
             *name = Some("xmlserialize");
             1
         }
-        NodeTag::T_SQLValueFunction => {
-            use types_nodes::SQLValueFunctionOp::*;
-            *name = Some(match node.as_sql_value_function().unwrap().op {
-                SVFOP_CURRENT_DATE => "current_date",
-                SVFOP_CURRENT_TIME | SVFOP_CURRENT_TIME_N => "current_time",
-                SVFOP_CURRENT_TIMESTAMP | SVFOP_CURRENT_TIMESTAMP_N => "current_timestamp",
-                SVFOP_LOCALTIME | SVFOP_LOCALTIME_N => "localtime",
-                SVFOP_LOCALTIMESTAMP | SVFOP_LOCALTIMESTAMP_N => "localtimestamp",
-                SVFOP_CURRENT_ROLE => "current_role",
-                SVFOP_CURRENT_USER => "current_user",
-                SVFOP_USER => "user",
-                SVFOP_SESSION_USER => "session_user",
-                SVFOP_CURRENT_CATALOG => "current_catalog",
-                SVFOP_CURRENT_SCHEMA => "current_schema",
-            });
-            2
-        }
         NodeTag::T_JsonParseExpr => {
             *name = Some("json");
             2

--- a/crates/backend/parser/parse_utilcmd/src/lib.rs
+++ b/crates/backend/parser/parse_utilcmd/src/lib.rs
@@ -3297,8 +3297,6 @@ fn alter_undefined_column(colname: &str, relname: &str) -> Box<PgError> {
 #[track_caller]
 #[cold]
 #[inline(never)]
-#[cold]
-#[inline(never)]
 fn cursor_at(mut e: Box<PgError>, src: Option<&[u8]>, location: i32) -> Box<PgError> {
     let pos =
         parser_small1::parser_errposition_source(src, location, mbutils::GetDatabaseEncoding());

--- a/crates/backend/tcop/dest/src/lib.rs
+++ b/crates/backend/tcop/dest/src/lib.rs
@@ -56,7 +56,6 @@ impl<'mcx> DestReceiver<'mcx> {
             }
             DestReceiver::ExplainSerialize(dr) => dr.receive_slot(slot),
             DestReceiver::TupleQueue(dr) => dr.receive_slot(slot),
-            other => other.unported("receiveSlot"),
         }
     }
 
@@ -81,7 +80,6 @@ impl<'mcx> DestReceiver<'mcx> {
                 dr.startup(operation, typeinfo);
                 Ok(())
             }
-            other => other.unported("rStartup"),
         }
     }
 
@@ -137,14 +135,6 @@ impl<'mcx> DestReceiver<'mcx> {
         }
     }
 
-    #[cold]
-    fn unported(&self, method: &str) -> ! {
-        panic!(
-            "DestReceiver {:?}.{method}: owner callbacks not ported yet \
-             (printtup.c/printsimple.c/spi.c)",
-            self.mydest()
-        )
-    }
 }
 
 // SetRemoteDestReceiverParams (printtup.c) at the enum boundary: C downcasts

--- a/crates/backend/tcop/utility/src/dispatch.rs
+++ b/crates/backend/tcop/utility/src/dispatch.rs
@@ -1992,17 +1992,6 @@ fn exec_alter_owner_non_et<'mcx>(
                 aclchk::get_rolespec_oid(stmt.newowner.expect("AlterOwnerStmt.newowner"), false)?;
             commands_tablespace::AlterTableSpaceOwner(mcx, name, newowner)
         }
-        types_nodes::parsenodes::ObjectType::OBJECT_DATABASE => {
-            let name = stmt
-                .object
-                .expect("AlterOwnerStmt.object")
-                .as_string()
-                .expect("database name String")
-                .sval;
-            let newowner =
-                aclchk::get_rolespec_oid(stmt.newowner.expect("AlterOwnerStmt.newowner"), false)?;
-            dbcommands::AlterDatabaseOwner(mcx, name, newowner).map(|_| ())
-        }
         types_nodes::parsenodes::ObjectType::OBJECT_EVENT_TRIGGER => {
             // C: ExecAlterOwnerStmt case OBJECT_EVENT_TRIGGER (alter.c) ->
             // AlterEventTriggerOwner (event_trigger.c). Address is dropped:

--- a/crates/backend/utils/adt/ruleutils/src/deparse.rs
+++ b/crates/backend/utils/adt/ruleutils/src/deparse.rs
@@ -606,10 +606,6 @@ pub(crate) fn get_rule_expr<'mcx>(
         NodeTag::T_ReturningExpr => {
             get_rule_expr(node.as_returning_expr().unwrap().retexpr, ctx, showimplicit)
         }
-        NodeTag::T_SetToDefault => {
-            ctx.buf.push_str("DEFAULT");
-            Ok(())
-        }
         other => gap("get_rule_expr", &format!("{other:?} deparse arm")),
     }
 }

--- a/crates/backend/utils/sort/tuplesort/src/lib.rs
+++ b/crates/backend/utils/sort/tuplesort/src/lib.rs
@@ -2251,7 +2251,6 @@ impl<'m> TuplesortData<'m> {
     /// restored across every already-stored memtuple (REMOVEABBREV).
     /// Out of line: inlined it doubled puttuple_full on no-abbrev lanes
     /// (m3 sort_limit +22 instr/row, jobs -1783120589/-1783120595).
-    #[inline(never)]
     /// Out of line as C keeps it (ssup->abbrev_converter is an indirect
     /// call): letting the converter fuse into the put complex regressed
     /// text_sort by register pressure after the spill landing's code growth.

--- a/crates/backend/utils/sort/tuplesort/src/ssup.rs
+++ b/crates/backend/utils/sort/tuplesort/src/ssup.rs
@@ -552,7 +552,6 @@ pub fn comparator_for_opfamily(
         // btoidfastcmp: unsigned; the zero-extended datum word compares exact.
         F_BTOIDSORTSUPPORT => SortComparator::Unsigned,
         F_BTINT8SORTSUPPORT | F_TIMESTAMP_SORTSUPPORT => SortComparator::SignedI64,
-        F_BTINT2SORTSUPPORT => SortComparator::Int16,
         F_BTTEXTSORTSUPPORT | F_BPCHAR_SORTSUPPORT => {
             varstr_comparator(sort_support_function == F_BPCHAR_SORTSUPPORT, collation)?
         }

--- a/crates/backend/utils/sort/tuplesort/src/tests.rs
+++ b/crates/backend/utils/sort/tuplesort/src/tests.rs
@@ -278,17 +278,17 @@ fn random_access_backward_rescan_markpos() {
     ts.performsort().unwrap();
     assert_eq!(ts.getdatum(true).unwrap().unwrap().value.as_i32(), 1);
     assert_eq!(ts.getdatum(true).unwrap().unwrap().value.as_i32(), 3);
-    ts.markpos();
+    ts.markpos().unwrap();
     assert_eq!(ts.getdatum(true).unwrap().unwrap().value.as_i32(), 5);
     // Backward: returns the tuple before the last-returned one.
     assert_eq!(ts.getdatum(false).unwrap().unwrap().value.as_i32(), 3);
-    ts.restorepos();
+    ts.restorepos().unwrap();
     assert_eq!(ts.getdatum(true).unwrap().unwrap().value.as_i32(), 5);
     assert_eq!(ts.getdatum(true).unwrap().unwrap().value.as_i32(), 9);
     assert!(ts.getdatum(true).unwrap().is_none());
     // Backward off EOF re-returns the last tuple.
     assert_eq!(ts.getdatum(false).unwrap().unwrap().value.as_i32(), 9);
-    ts.rescan();
+    ts.rescan().unwrap();
     assert_eq!(ts.getdatum(true).unwrap().unwrap().value.as_i32(), 1);
     ts.end();
 }

--- a/scripts/check-core.sh
+++ b/scripts/check-core.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Keep the production server buildable from the lockfile.
+cargo check --locked --bin postgres
+
+# Fast coverage for the core paths guarded below.
+cargo test --locked -p coerce -p clauses -p planner -p utility \
+    -p nodes_core -p outfuncs -p catalog_dependency -p catalog_objectaddress -p tablecmds \
+    -p spgist -p nodeworktablescan -p nodefunctionscan -p nodetablefuncscan -p nodeagg \
+    -p execmain -p tcop_dest -p tuplesort -p indexam -p execexpr \
+    -p parse_expr -p parse_collate -p parse_target -p ruleutils -p parse_utilcmd
+
+# The workspace still has legacy warnings. Turn the classes fixed by this
+# change into hard errors only for the crates that are clean today, so new
+# regressions cannot silently reappear.
+cargo rustc --locked -p coerce --lib -- -D unreachable-patterns
+cargo rustc --locked -p clauses --lib -- -D unreachable-patterns
+cargo rustc --locked -p utility --lib -- -D unreachable-patterns
+cargo rustc --locked -p planner --lib -- -D unused-must-use -D unreachable-patterns
+cargo rustc --locked -p nodes_core --lib -- -D unreachable-patterns
+cargo rustc --locked -p outfuncs --lib -- -D unreachable-patterns
+cargo rustc --locked -p catalog_dependency --lib -- -D unreachable-patterns
+cargo rustc --locked -p catalog_objectaddress --lib -- -D unreachable-patterns
+cargo rustc --locked -p tablecmds --lib -- -D unreachable-patterns
+cargo rustc --locked -p spgist --lib -- -D unused-must-use
+cargo rustc --locked -p nodeworktablescan --lib -- -D unused-must-use
+cargo rustc --locked -p nodefunctionscan --lib -- -D unused-must-use
+cargo rustc --locked -p nodetablefuncscan --lib -- -D unused-must-use
+cargo rustc --locked -p nodeagg --lib -- -D unused-must-use
+cargo rustc --locked -p tcop_dest --lib -- -D unreachable-patterns
+cargo rustc --locked -p tuplesort --lib -- -D unreachable-patterns -D unused-attributes
+cargo rustc --locked -p indexam --lib -- -D unreachable-patterns
+cargo rustc --locked -p execexpr --lib -- -D unreachable-patterns -D unused-attributes
+cargo rustc --locked -p parse_expr --lib -- -D unreachable-patterns
+cargo rustc --locked -p parse_collate --lib -- -D unreachable-patterns
+cargo rustc --locked -p parse_target --lib -- -D unreachable-patterns
+cargo rustc --locked -p ruleutils --lib -- -D unreachable-patterns
+cargo rustc --locked -p parse_utilcmd --lib -- -D unused-attributes


### PR DESCRIPTION
## Summary

- propagate previously ignored PgResult values in planner, SP-GiST buffer handling, and executor paths
- remove duplicate unreachable branches and duplicate attributes in core parser, executor, catalog, and sort code
- add focused core CI with a locked server build, 941 tests, and 23 crate-specific hard warning gates

## Why

The README identifies testing and reliability as the project’s current priorities. Ignored results could conceal buffer, tuplestore, or expression-walker failures; the new warning gates prevent these classes of regression in the covered crates.

## Validation

- CARGO_TARGET_DIR=target scripts/check-core.sh
- 941 targeted tests passed
- cargo check --locked --bin postgres
- git diff --check
- bash -n scripts/check-core.sh

## Scope note

The remaining unreachable-pattern warnings are emitted by generated parser actions in crates/backend/parser/gram_core/src/actions.rs and are intentionally left untouched here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated validation for pushes and pull requests.
  * Added comprehensive core build, test, and compiler-warning checks.

* **Bug Fixes**
  * Improved propagation of database execution and buffer-management errors.
  * Removed unreachable or duplicate processing paths.
  * Corrected handling of collation propagation and expression transformation.

* **Tests**
  * Strengthened sorting tests to verify operation failures instead of ignoring them.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->