### PR TITLE
Harden pgclient SCRAM authentication

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12521,6 +12521,7 @@ dependencies = [
  "pg_b64",
  "pg_hmac",
  "pg_md5",
+ "pg_strong_random",
  "postgres_seams",
  "saslprep",
  "scram_common",

--- a/crates/interfaces/pgclient/Cargo.toml
+++ b/crates/interfaces/pgclient/Cargo.toml
@@ -16,6 +16,7 @@ mcx = { path = "../../_support/mcx" }
 pg_b64 = { path = "../../common/base64" }
 pg_hmac = { path = "../../common/hmac" }
 pg_md5 = { path = "../../common/md5" }
+pg_strong_random = { path = "../../port/pg_strong_random" }
 postgres_seams = { path = "../../backend/tcop/postgres_seams" }
 saslprep = { path = "../../common/saslprep" }
 scram_common = { path = "../../common/scram_common" }

--- a/crates/interfaces/pgclient/src/auth.rs
+++ b/crates/interfaces/pgclient/src/auth.rs
@@ -3,7 +3,70 @@
 // ReadyForQuery.
 use types_error::PgResult;
 
-use crate::{be_i32, cstr_at, msg, parse_error_fields, PgConn};
+use crate::{be_i32, msg, parse_error_fields, PgConn};
+
+const MALFORMED_AUTH_REQUEST: &str = "malformed authentication request from server";
+
+fn authentication_type(body: &[u8]) -> Result<i32, String> {
+    body.get(..4).map(be_i32).ok_or_else(|| MALFORMED_AUTH_REQUEST.into())
+}
+
+fn sasl_mechanisms(body: &[u8]) -> Result<Vec<String>, String> {
+    let mut mechanisms = Vec::new();
+    let mut pos = 4;
+    loop {
+        let tail = body.get(pos..).ok_or_else(|| MALFORMED_AUTH_REQUEST.to_string())?;
+        let end = tail
+            .iter()
+            .position(|&byte| byte == 0)
+            .ok_or_else(|| MALFORMED_AUTH_REQUEST.to_string())?;
+        if end == 0 {
+            if pos + 1 != body.len() {
+                return Err(MALFORMED_AUTH_REQUEST.into());
+            }
+            return Ok(mechanisms);
+        }
+        mechanisms.push(String::from_utf8_lossy(&tail[..end]).into_owned());
+        pos += end + 1;
+    }
+}
+
+fn authentication_payload<'a>(
+    body: &'a [u8],
+    expected_type: i32,
+    unexpected_message: &'static str,
+) -> Result<&'a [u8], String> {
+    if authentication_type(body)? != expected_type {
+        return Err(unexpected_message.into());
+    }
+    Ok(&body[4..])
+}
+
+fn generate_nonce() -> Result<[u8; scram_common::SCRAM_RAW_NONCE_LEN], String> {
+    let mut nonce = [0u8; scram_common::SCRAM_RAW_NONCE_LEN];
+    if !pg_strong_random::pg_strong_random(&mut nonce) {
+        return Err("could not generate nonce".into());
+    }
+    Ok(nonce)
+}
+
+fn scram_iterations(fields: &[&str]) -> Result<i32, String> {
+    match scram_attr(fields, 'i').and_then(|value| {
+        value
+            .parse::<i32>()
+            .map_err(|_| "malformed SCRAM message (invalid iteration count)".to_string())
+    }) {
+        Ok(iterations) if iterations > 0 => Ok(iterations),
+        _ => Err("malformed SCRAM message (invalid iteration count)".into()),
+    }
+}
+
+fn validate_server_nonce(client_nonce: &str, server_nonce: &str) -> Result<(), String> {
+    if server_nonce.len() <= client_nonce.len() || !server_nonce.starts_with(client_nonce) {
+        return Err("invalid SCRAM response (nonce mismatch)".into());
+    }
+    Ok(())
+}
 
 pub(crate) fn handshake(
     conn: &mut PgConn,
@@ -17,7 +80,10 @@ pub(crate) fn handshake(
         };
         match t {
             b'R' => {
-                let authtype = be_i32(&mbody[0..4]);
+                let authtype = match authentication_type(&mbody) {
+                    Ok(authtype) => authtype,
+                    Err(err) => return Ok(Err(err)),
+                };
                 match authtype {
                     0 => {}
                     3 => {
@@ -36,7 +102,9 @@ pub(crate) fn handshake(
                         let Some(pw) = password else {
                             return Ok(Err("fe_sendauth: no password supplied".into()));
                         };
-                        let salt = &mbody[4..8];
+                        let Some(salt) = mbody.get(4..8) else {
+                            return Ok(Err(MALFORMED_AUTH_REQUEST.into()));
+                        };
                         let stage1 = pg_md5::pg_md5_encrypt(pw.as_bytes(), user.as_bytes());
                         let hex = &stage1[3..];
                         let stage2 = pg_md5::pg_md5_encrypt(hex, salt);
@@ -51,13 +119,10 @@ pub(crate) fn handshake(
                         let Some(pw) = password else {
                             return Ok(Err("fe_sendauth: no password supplied".into()));
                         };
-                        let mut mechs = Vec::new();
-                        let mut p = 4;
-                        while p < mbody.len() && mbody[p] != 0 {
-                            let (m, next) = cstr_at(&mbody, p);
-                            mechs.push(m);
-                            p = next;
-                        }
+                        let mechs = match sasl_mechanisms(&mbody) {
+                            Ok(mechs) => mechs,
+                            Err(err) => return Ok(Err(err)),
+                        };
                         if !mechs.iter().any(|m| m == scram_common::SCRAM_SHA_256_NAME) {
                             return Ok(Err(format!(
                                 "none of the server's SASL authentication mechanisms are supported (offered: {})",
@@ -125,15 +190,10 @@ fn scram_exchange(conn: &mut PgConn, password: &str) -> PgResult<Result<(), Stri
         .map(|v| v.as_slice().to_vec())
         .unwrap_or_else(|| password.as_bytes().to_vec());
 
-    let mut raw_nonce = [0u8; scram_common::SCRAM_RAW_NONCE_LEN];
-    if std::io::Read::read_exact(
-        &mut std::fs::File::open("/dev/urandom").expect("open /dev/urandom"),
-        &mut raw_nonce,
-    )
-    .is_err()
-    {
-        return Ok(Err("could not generate nonce".into()));
-    }
+    let raw_nonce = match generate_nonce() {
+        Ok(nonce) => nonce,
+        Err(err) => return Ok(Err(err)),
+    };
     let client_nonce = b64(&raw_nonce);
     let client_first_bare = format!("n=,r={client_nonce}");
 
@@ -154,25 +214,32 @@ fn scram_exchange(conn: &mut PgConn, password: &str) -> PgResult<Result<(), Stri
     if t == b'E' {
         return Ok(Err(parse_error_fields(&mbody)));
     }
-    if t != b'R' || be_i32(&mbody[0..4]) != 11 {
+    if t != b'R' {
         return Ok(Err("expected SASL continue message from server".into()));
     }
-    let server_first = String::from_utf8_lossy(&mbody[4..]).into_owned();
+    let server_first = match authentication_payload(
+        &mbody,
+        11,
+        "expected SASL continue message from server",
+    ) {
+        Ok(payload) => String::from_utf8_lossy(payload).into_owned(),
+        Err(err) => return Ok(Err(err)),
+    };
     let fields: Vec<&str> = server_first.split(',').collect();
     let server_nonce = match scram_attr(&fields, 'r') {
         Ok(v) => v.to_string(),
         Err(e) => return Ok(Err(e)),
     };
-    if !server_nonce.starts_with(&client_nonce) {
-        return Ok(Err("invalid SCRAM response (nonce mismatch)".into()));
+    if let Err(err) = validate_server_nonce(&client_nonce, &server_nonce) {
+        return Ok(Err(err));
     }
     let salt = match scram_attr(&fields, 's').and_then(b64_decode) {
         Ok(v) => v,
         Err(e) => return Ok(Err(e)),
     };
-    let iterations: i32 = match scram_attr(&fields, 'i').map(|s| s.parse::<i32>()) {
-        Ok(Ok(v)) => v,
-        _ => return Ok(Err("malformed SCRAM message (invalid iteration count)".into())),
+    let iterations = match scram_iterations(&fields) {
+        Ok(iterations) => iterations,
+        Err(err) => return Ok(Err(err)),
     };
 
     let salted = scram_common::scram_salted_password(&prep, &salt, iterations)?;
@@ -198,10 +265,17 @@ fn scram_exchange(conn: &mut PgConn, password: &str) -> PgResult<Result<(), Stri
     if t == b'E' {
         return Ok(Err(parse_error_fields(&mbody)));
     }
-    if t != b'R' || be_i32(&mbody[0..4]) != 12 {
+    if t != b'R' {
         return Ok(Err("expected SASL final message from server".into()));
     }
-    let server_final = String::from_utf8_lossy(&mbody[4..]).into_owned();
+    let server_final = match authentication_payload(
+        &mbody,
+        12,
+        "expected SASL final message from server",
+    ) {
+        Ok(payload) => String::from_utf8_lossy(payload).into_owned(),
+        Err(err) => return Ok(Err(err)),
+    };
     let ffields: Vec<&str> = server_final.split(',').collect();
     let server_sig_b64 = match scram_attr(&ffields, 'v') {
         Ok(v) => v.to_string(),
@@ -231,5 +305,41 @@ mod tests {
         assert_eq!(scram_attr(&f, 'r').unwrap(), "abc");
         assert_eq!(scram_attr(&f, 'i').unwrap(), "4096");
         assert!(scram_attr(&f, 'v').is_err());
+    }
+
+    #[test]
+    fn authentication_messages_require_complete_headers_and_lists() {
+        assert!(authentication_type(&[]).is_err());
+        assert_eq!(authentication_type(&10i32.to_be_bytes()).unwrap(), 10);
+        assert!(authentication_payload(&[0, 0, 0], 11, "wrong type").is_err());
+
+        let mut request = 10i32.to_be_bytes().to_vec();
+        request.extend_from_slice(b"SCRAM-SHA-256\0OTHER\0\0");
+        assert_eq!(
+            sasl_mechanisms(&request).unwrap(),
+            vec!["SCRAM-SHA-256", "OTHER"]
+        );
+
+        request.pop();
+        assert!(sasl_mechanisms(&request).is_err());
+        request.extend_from_slice(b"\0trailing");
+        assert!(sasl_mechanisms(&request).is_err());
+    }
+
+    #[test]
+    fn scram_parameters_reject_invalid_iterations_and_nonce_reuse() {
+        assert_eq!(scram_iterations(&["i=4096"]).unwrap(), 4096);
+        assert!(scram_iterations(&["i=0"]).is_err());
+        assert!(scram_iterations(&["i=-1"]).is_err());
+        assert!(scram_iterations(&["i=invalid"]).is_err());
+
+        assert!(validate_server_nonce("client", "client-server").is_ok());
+        assert!(validate_server_nonce("client", "client").is_err());
+        assert!(validate_server_nonce("client", "other-server").is_err());
+    }
+
+    #[test]
+    fn nonce_uses_the_strong_random_source() {
+        assert!(generate_nonce().is_ok());
     }
 }


### PR DESCRIPTION
## Summary

- route SCRAM nonce generation through the project’s sanctioned pg_strong_random entropy source instead of opening /dev/urandom with expect
- reject truncated authentication headers, MD5 salts, and unterminated SASL mechanism lists without panicking
- require a positive SCRAM iteration count
- require the server nonce to extend, rather than merely equal, the client nonce
- add focused regression tests for malformed authentication and SCRAM parameters

## Why

The client previously indexed server-controlled authentication messages without checking their lengths, so a malformed server response could panic during connection startup. Directly opening /dev/urandom also bypassed the project’s portable, failure-aware, and simulation-compatible entropy seam.

## Validation

- CARGO_TARGET_DIR=target cargo test --locked -p pgclient (18 passed)
- CARGO_TARGET_DIR=target cargo test --locked -p pg_strong_random (5 passed)
- CARGO_TARGET_DIR=target cargo rustc --locked -p pgclient --lib -- -D unused-must-use -D unreachable-patterns -D unused-attributes
- CARGO_TARGET_DIR=target cargo check --locked -p dblink -p postgres_fdw -p walreceiver
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication handling for malformed or incomplete server responses.
  * Added validation for authentication types, message lengths, SASL mechanisms, SCRAM iterations, and nonce structure.
  * Authentication failures now return clear errors instead of causing unexpected application crashes.
  * Improved SCRAM nonce generation and validation for more reliable authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->