### PR TITLE
regress/isolation-overlay: reproduce Unique EPQ failure

### DIFF
--- a/regress/isolation-overlay/expected/epq-short-unique.out
+++ b/regress/isolation-overlay/expected/epq-short-unique.out
@@ -1,0 +1,67 @@
+Parsed test spec with 3 sessions
+
+starting permutation: expl s1u lock s1c final
+step expl: 
+ EXPLAIN (COSTS OFF)
+ WITH requested AS (SELECT 1 AS id),
+ lock_ids AS (
+   SELECT id FROM requested
+   UNION
+   SELECT t.parent_id
+     FROM epq_unique t JOIN requested r USING (id)
+    WHERE t.parent_id IS NOT NULL
+ )
+ SELECT t.id, t.value
+   FROM epq_unique t JOIN lock_ids USING (id)
+  ORDER BY t.id
+  FOR UPDATE OF t;
+
+QUERY PLAN                                                                                  
+--------------------------------------------------------------------------------------------
+LockRows                                                                                    
+  CTE requested                                                                             
+    ->  Result                                                                              
+  ->  Nested Loop                                                                           
+        ->  Subquery Scan on lock_ids                                                       
+              ->  Unique                                                                    
+                    ->  Sort                                                                
+                          Sort Key: requested.id                                            
+                          ->  Append                                                        
+                                ->  CTE Scan on requested                                   
+                                ->  Nested Loop                                             
+                                      ->  CTE Scan on requested r                           
+                                      ->  Index Scan using epq_unique_pkey on epq_unique t_1
+                                            Index Cond: (id = r.id)                         
+                                            Filter: (parent_id IS NOT NULL)                 
+        ->  Index Scan using epq_unique_pkey on epq_unique t                                
+              Index Cond: (id = lock_ids.id)                                                
+(17 rows)
+
+step s1u: UPDATE epq_unique SET value = 'after' WHERE id = 1;
+step lock: 
+ WITH requested AS (SELECT 1 AS id),
+ lock_ids AS (
+   SELECT id FROM requested
+   UNION
+   SELECT t.parent_id
+     FROM epq_unique t JOIN requested r USING (id)
+    WHERE t.parent_id IS NOT NULL
+ )
+ SELECT t.id, t.value
+   FROM epq_unique t JOIN lock_ids USING (id)
+  ORDER BY t.id
+  FOR UPDATE OF t;
+ <waiting ...>
+step s1c: COMMIT;
+step lock: <... completed>
+id|value
+--+-----
+ 1|after
+(1 row)
+
+step final: SELECT id, value FROM epq_unique ORDER BY id;
+id|value
+--+-----
+ 1|after
+(1 row)
+

--- a/regress/isolation-overlay/schedule.extra
+++ b/regress/isolation-overlay/schedule.extra
@@ -16,3 +16,4 @@ test: epq-short-material
 test: epq-short-valuesscan
 test: epq-short-ctescan
 test: epq-short-functionscan
+test: epq-short-unique

--- a/regress/isolation-overlay/specs/epq-short-unique.spec
+++ b/regress/isolation-overlay/specs/epq-short-unique.spec
@@ -1,0 +1,56 @@
+# Reproduce a Unique node inside an EPQ recheck plan. The waiting SELECT
+# must rebuild its row after s1 commits and return the updated value.
+
+setup
+{
+ CREATE TABLE epq_unique (id int PRIMARY KEY, parent_id int, value text NOT NULL);
+ INSERT INTO epq_unique VALUES (1, NULL, 'before');
+}
+
+teardown
+{
+ DROP TABLE epq_unique;
+}
+
+session s1
+setup       { BEGIN ISOLATION LEVEL READ COMMITTED; }
+step s1u    { UPDATE epq_unique SET value = 'after' WHERE id = 1; }
+step s1c    { COMMIT; }
+
+session s2
+step expl
+{
+ EXPLAIN (COSTS OFF)
+ WITH requested AS (SELECT 1 AS id),
+ lock_ids AS (
+   SELECT id FROM requested
+   UNION
+   SELECT t.parent_id
+     FROM epq_unique t JOIN requested r USING (id)
+    WHERE t.parent_id IS NOT NULL
+ )
+ SELECT t.id, t.value
+   FROM epq_unique t JOIN lock_ids USING (id)
+  ORDER BY t.id
+  FOR UPDATE OF t;
+}
+step lock
+{
+ WITH requested AS (SELECT 1 AS id),
+ lock_ids AS (
+   SELECT id FROM requested
+   UNION
+   SELECT t.parent_id
+     FROM epq_unique t JOIN requested r USING (id)
+    WHERE t.parent_id IS NOT NULL
+ )
+ SELECT t.id, t.value
+   FROM epq_unique t JOIN lock_ids USING (id)
+  ORDER BY t.id
+  FOR UPDATE OF t;
+}
+
+session s3
+step final  { SELECT id, value FROM epq_unique ORDER BY id; }
+
+permutation expl s1u lock s1c final


### PR DESCRIPTION
Add a PostgreSQL-oracle isolation case where a SELECT FOR UPDATE waits behind a concurrent update and then rebuilds a plan containing Unique. pgrust currently errors during EvalPlanQualStart instead of returning the updated row.