### PR TITLE
vacuum morsels: bound the leader's round consumption at the resume point (fixes #66)

### DIFF
--- a/crates/backend/access/heap/vacuumlazy/src/morsels.rs
+++ b/crates/backend/access/heap/vacuumlazy/src/morsels.rs
@@ -62,7 +62,7 @@ use ::types_storage::buf::{BufferAccessStrategy, BufferAccessStrategyType};
 use ::types_storage::bufpage::PageRef;
 use ::types_storage::ReadBufferMode;
 use ::vacuum_morsels::{
-    merge_dead_runs, resume_granule, verify_prefix_coverage, ClaimRecord, CoverageError,
+    leader_round_work, resume_granule, verify_prefix_coverage, ClaimRecord, CoverageError,
     QuiesceState, ScanCounters, SkipMapParams, VacScanLocal, VacuumBlockSource, VM_ALL_FROZEN,
     VM_ALL_VISIBLE,
 };
@@ -415,12 +415,20 @@ pub(crate) fn scan_rounds(vacrel: &mut LVRelState<'_, '_>, k: i32) -> PgResult<S
         vacrel.skippedallvis |= source.skipsallvis_before(resume_g);
         clock.finalize_ns += t_finalize.elapsed().as_nanos() as u64;
 
+        // Everything at/above the (possibly rewound) resume point is the
+        // serial arm's to re-scan; consuming it in the round too would
+        // double-count num_items — dead_items_add is add-not-replace
+        // (issue #66). Healthy rounds carry nothing above the bound.
+        let resume_bound: Option<BlockNumber> =
+            if resume_g < total { Some(source.block_of(resume_g).block) } else { None };
+        let (round_runs, deferred) = leader_round_work(&locals, resume_bound);
+
         // Merge the per-worker dead-TID runs into the round authority store
         // (the ONE serial O(dead TIDs) step per round — doc §3.2).
         let t_merge = std::time::Instant::now();
         {
             let super::LVRelState { dead_items, dead_items_info, .. } = &mut *vacrel;
-            for run in merge_dead_runs(&locals) {
+            for run in &round_runs {
                 dead_items_add(
                     dead_items.as_mut().expect("dead_items live during scan"),
                     dead_items_info,
@@ -478,10 +486,9 @@ pub(crate) fn scan_rounds(vacrel: &mut LVRelState<'_, '_>, k: i32) -> PgResult<S
         }
 
         // Deferred blocking-cleanup pages (§5.3): leader-serial, BEFORE the
-        // round's INDEX phase, so the round's dead set is complete.
-        let mut deferred: Vec<BlockNumber> =
-            locals.iter().flat_map(|l| l.deferred_cleanup.iter().copied()).collect();
-        deferred.sort_unstable();
+        // round's INDEX phase, so the round's dead set is complete. Pages
+        // at/above the resume bound were dropped by leader_round_work — the
+        // serial arm's blocking-cleanup path handles them on the re-scan.
         for blk in deferred {
             leader_deferred_block(vacrel, &source, blk)?;
         }

--- a/crates/backend/commands/vacuum_morsels/src/lib.rs
+++ b/crates/backend/commands/vacuum_morsels/src/lib.rs
@@ -492,5 +492,45 @@ pub fn merge_dead_runs(locals: &[VacScanLocal]) -> Vec<DeadRun> {
     out
 }
 
+/// The leader's round consumption — dead runs to merge into the round
+/// authority store plus deferred blocking-cleanup pages to process serially
+/// — bounded by the resume point (upstream issue #66). On a §5.2 coverage
+/// trip `resume_g` rewinds below granules other workers completed, and the
+/// serial arm re-scans everything from there: re-pruning re-collects the
+/// same LP_DEAD items, and `dead_items_add`'s num_items accounting is
+/// add-not-replace, so consuming at/above-bound work here too would count
+/// those dead tuples twice. `resume_bound` is the first block the serial
+/// arm will visit (`block_of(resume_g)`), `None` when the round completed.
+///
+/// The bound filters BEFORE the run merge: on an `OverlapAt` trip the
+/// double-claimed block sits at/above the bound, and the merge's
+/// blocks-disjoint-across-Locals contract only holds for the below-bound
+/// remainder. Healthy rounds carry nothing at/above the bound (the
+/// coverage guard errors on ScannedBeyondResume), so this is a no-op there.
+pub fn leader_round_work(
+    locals: &[VacScanLocal],
+    resume_bound: Option<u32>,
+) -> (Vec<DeadRun>, Vec<u32>) {
+    let below = |b: u32| resume_bound.is_none_or(|r| b < r);
+    let mut runs: Vec<DeadRun> = locals
+        .iter()
+        .flat_map(|l| l.runs.iter())
+        .filter(|r| below(r.block))
+        .cloned()
+        .collect();
+    runs.sort_unstable_by_key(|r| r.block);
+    debug_assert!(
+        runs.windows(2).all(|w| w[0].block < w[1].block),
+        "below-bound blocks are owned by exactly one Local"
+    );
+    let mut deferred: Vec<u32> = locals
+        .iter()
+        .flat_map(|l| l.deferred_cleanup.iter().copied())
+        .filter(|&b| below(b))
+        .collect();
+    deferred.sort_unstable();
+    (runs, deferred)
+}
+
 #[cfg(test)]
 mod tests;

--- a/crates/backend/commands/vacuum_morsels/src/tests.rs
+++ b/crates/backend/commands/vacuum_morsels/src/tests.rs
@@ -537,3 +537,65 @@ fn run_merge_degenerate_shapes() {
     assert_eq!(merged[0].block, 3);
     assert_eq!(merged[1].block, 9);
 }
+
+// ---------------------------------------------------------------------------
+// 5. §5.2 recovery vs the leader's round consumption (upstream issue #66)
+// ---------------------------------------------------------------------------
+
+// On a coverage trip the resume point rewinds below work other workers
+// already completed, and the serial arm re-scans from there. Re-pruning a
+// pruned page re-collects the same LP_DEAD items, and dead_items_add's
+// num_items accounting is add-not-replace: any dead run or deferred-cleanup
+// page at/above the rewound resume point that the leader also consumes in
+// the round is counted twice — debug builds trip collect_dead_tids'
+// num_items assert, release builds silently misreport dead tuples.
+#[test]
+fn coverage_trip_drops_round_work_above_the_rewound_resume() {
+    // Identity granule->block mapping (no skips). Worker 0 owned [3,5) and
+    // is LOST (§9 lose-local). Worker 1 scanned [0,3): a dead run below the
+    // hole plus a deferred page below it. Worker 2 scanned [5,8): a dead
+    // run and a deferred blocking-cleanup page ABOVE the hole.
+    let mut w1 = VacScanLocal::new(1, 1000, 1000);
+    w1.claims = vec![ClaimRecord { start: 0, end: 3, scanned: true }];
+    w1.record_dead(1, vec![1, 2]);
+    w1.deferred_cleanup.push(2);
+    let mut w2 = VacScanLocal::new(2, 1000, 1000);
+    w2.claims = vec![ClaimRecord { start: 5, end: 8, scanned: true }];
+    w2.record_dead(6, vec![3]);
+    w2.deferred_cleanup.push(7);
+    let locals = vec![w1, w2];
+
+    let total = 8;
+    let mut resume = resume_granule(&locals, total);
+    assert_eq!(resume, 8, "no no-op'd claims: the lost Local leaves a silent hole");
+    let err = verify_prefix_coverage(&locals, resume).unwrap_err();
+    assert_eq!(err, CoverageError::HoleAt(3));
+    // The documented §5.2 recovery (morsels.rs scan_rounds): rewind to the
+    // hole and hand [resume, ...) to the serial arm.
+    resume = match err {
+        CoverageError::HoleAt(g) | CoverageError::OverlapAt(g) => g.min(resume),
+        CoverageError::ScannedBeyondResume { .. } => resume,
+    };
+    assert_eq!(resume, 3);
+    let resume_bound = resume as u32;
+
+    // The leader's round consumption, as morsels.rs builds it today.
+    let runs = merge_dead_runs(&locals);
+    let mut deferred: Vec<u32> =
+        locals.iter().flat_map(|l| l.deferred_cleanup.iter().copied()).collect();
+    deferred.sort_unstable();
+
+    // Work below the hole is the round's to keep: the serial arm never
+    // revisits it.
+    assert!(runs.iter().any(|r| r.block == 1));
+    assert!(deferred.contains(&2));
+    // Work at/above the rewound resume point belongs to the serial re-scan.
+    assert!(
+        runs.iter().all(|r| r.block < resume_bound),
+        "dead runs at/above the resume point double-count num_items once the serial arm re-prunes them"
+    );
+    assert!(
+        deferred.iter().all(|&b| b < resume_bound),
+        "deferred pages at/above the resume point double-count num_items once the serial arm re-prunes them"
+    );
+}

--- a/crates/backend/commands/vacuum_morsels/src/tests.rs
+++ b/crates/backend/commands/vacuum_morsels/src/tests.rs
@@ -579,11 +579,8 @@ fn coverage_trip_drops_round_work_above_the_rewound_resume() {
     assert_eq!(resume, 3);
     let resume_bound = resume as u32;
 
-    // The leader's round consumption, as morsels.rs builds it today.
-    let runs = merge_dead_runs(&locals);
-    let mut deferred: Vec<u32> =
-        locals.iter().flat_map(|l| l.deferred_cleanup.iter().copied()).collect();
-    deferred.sort_unstable();
+    // The leader's round consumption, as morsels.rs builds it.
+    let (runs, deferred) = leader_round_work(&locals, Some(resume_bound));
 
     // Work below the hole is the round's to keep: the serial arm never
     // revisits it.
@@ -598,4 +595,50 @@ fn coverage_trip_drops_round_work_above_the_rewound_resume() {
         deferred.iter().all(|&b| b < resume_bound),
         "deferred pages at/above the resume point double-count num_items once the serial arm re-prunes them"
     );
+}
+
+// With no bound (a completed round), leader_round_work's collect+sort is
+// exactly the k-way merge plus the raw deferred ledger.
+#[test]
+fn leader_round_work_unbounded_matches_merge() {
+    let mut rng = Rng::new(0x66_66_66);
+    for _ in 0..200 {
+        let workers = 1 + rng.below(6) as usize;
+        let total_blocks = rng.below(200) as u32;
+        let mut locals: Vec<VacScanLocal> =
+            (0..workers).map(|w| VacScanLocal::new(w, 1000, 1000)).collect();
+        let mut b = 0u32;
+        while b < total_blocks {
+            let end = (b + 1 + rng.below(MAX_CLAIM) as u32).min(total_blocks);
+            let w = rng.below(workers as u64) as usize;
+            for blk in b..end {
+                if rng.chance(50) {
+                    locals[w].record_dead(blk, vec![1 + (blk % 7) as u16]);
+                }
+                if rng.chance(10) {
+                    locals[w].deferred_cleanup.push(blk);
+                }
+            }
+            b = end;
+        }
+        let (runs, deferred) = leader_round_work(&locals, None);
+        assert_eq!(runs, merge_dead_runs(&locals));
+        let mut expect: Vec<u32> =
+            locals.iter().flat_map(|l| l.deferred_cleanup.iter().copied()).collect();
+        expect.sort_unstable();
+        assert_eq!(deferred, expect);
+        // A bound splits both consistently: kept strictly below, rest gone.
+        let bound = (total_blocks / 2).max(1);
+        let (bruns, bdef) = leader_round_work(&locals, Some(bound));
+        assert!(bruns.iter().all(|r| r.block < bound));
+        assert!(bdef.iter().all(|&d| d < bound));
+        assert_eq!(
+            bruns,
+            runs.iter().filter(|r| r.block < bound).cloned().collect::<Vec<_>>()
+        );
+        assert_eq!(
+            bdef,
+            deferred.iter().copied().filter(|&d| d < bound).collect::<Vec<_>>()
+        );
+    }
 }


### PR DESCRIPTION
Fixes #66. Independent branch off main.

On a §5.2 coverage trip, `resume_g` rewinds below granules other workers already completed, and the serial arm re-scans from there. Re-pruning a pruned page re-collects the same LP_DEAD items, and `dead_items_add`'s `num_items` is add-not-replace — so anything the leader consumed from the round at/above the rewound resume point gets counted twice (debug: `collect_dead_tids`' assert trips; release: silent dead-tuple misreport into progress reporting and downstream decisions).

The issue names the deferred blocking-cleanup pages; while fixing it I found the **dead-run merge has the same exposure**: `merge_dead_runs` folds all workers' runs unfiltered, so above-the-hole runs double-count identically once the serial arm re-prunes those blocks. Both are fixed with one bound.

## Changes

- **`vacuum_morsels`**: new pure `leader_round_work(locals, resume_bound)` — the dead runs to merge into the round authority store and the deferred pages the leader processes, both filtered strictly below the resume point (`None` bound on a completed round). Filtering happens **before** the merge: on an `OverlapAt` trip the double-claimed block sits at/above the bound, and the merge's blocks-disjoint-across-Locals contract only holds for the below-bound remainder.
- **`vacuumlazy` morsels.rs**: the leader computes the bound right after the coverage check (`block_of(resume_g)`, i.e. the first block the serial arm will visit) and consumes only `leader_round_work`'s output. At/above-bound deferred pages are left to the serial arm's blocking-cleanup path, which the C body already handles — mirroring how `skipsallvis_before(resume_g)` already filters skip decisions at the resume point.
- Healthy rounds are behavior-neutral: the coverage guard errors on `ScannedBeyondResume`, so nothing above the bound exists unless the guard tripped — pinned by a 200-case random parity sweep (`leader_round_work(locals, None)` ≡ `merge_dead_runs` + raw ledger; any bound splits both consistently).

## Testing (TDD, red→green in the container)

- **Red** (`431534b`): `coverage_trip_drops_round_work_above_the_rewound_resume` drives the issue's exact scenario — a lost Local holding lower granules (`HoleAt` rewind) while a surviving worker above the hole carries both a dead run and a deferred cleanup page — against the leader's round consumption as morsels.rs builds it today. Fails: `dead runs at/above the resume point double-count num_items once the serial arm re-prunes them`.
- **Green** (tip): same assertions through the real `leader_round_work`; below-hole work is kept (the serial arm never revisits it), at/above-bound work is dropped. All 13 `vacuum_morsels` tests + the `vacuumlazy` suite pass. Ubuntu 26.04, rustc 1.96.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved vacuum recovery after coverage gaps by preventing duplicate processing of dead-item runs and deferred cleanup pages.
  * Ensured resumed processing only includes work below the recovery boundary.

* **Tests**
  * Added coverage for recovery scenarios, leader processing, and randomized validation of bounded and unbounded cleanup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->