### PR TITLE
postmaster: crash-isolation contract doc + torn-state-under-LWLock reinit test (addresses #67)

### DIFF
--- a/GOAL.md
+++ b/GOAL.md
@@ -42,7 +42,12 @@ Claims are made at three levels, each with its own evidence:
   no-drop node trees, enum dispatch instead of function pointers,
   resolve-once carriers, thread-per-backend instead of process-per-backend.
   Deviations from C's shape are taken only when they are the *reason* we
-  can be faster, and are proven by benchmark.
+  can be faster, and are proven by benchmark. Thread-per-backend changes
+  the crash-isolation contract — caught panics get C's full
+  SIGQUIT-and-reset choreography in-process, but memory-unsafety signals
+  kill the whole server and an external supervisor must restart it; the
+  contract, its torn-state reasoning, and its tests are documented in
+  `docs/crash-isolation.md`.
 - Anything unported fails loudly with a named panic — no silent wrong
   answers, ever. The frontier of named panics is the work queue.
 - When a unit loses to C, the loss is attributed at the assembly level and

--- a/crates/backend/postmaster/postmaster/tests/crash_restart_torn.rs
+++ b/crates/backend/postmaster/postmaster/tests/crash_restart_torn.rs
@@ -1,0 +1,238 @@
+//! Torn-shared-state arm of the catchable-crash choreography (upstream
+//! issue #67, hardening item 2): a REAL panic unwinds a backend thread
+//! while it HOLDS an LWLock mid-mutation of shared state. Locking is
+//! C-style, not RAII — nothing releases on unwind — so the lock stays held
+//! and the mutation stays half-applied, exactly the torn state C's quickdie
+//! also leaves behind (C only ever risks *shared* memory this way; here it
+//! is the whole address space, which is why the ladder must be exercised
+//! against it). The reinit arm must clear both: LWLockResetAfterCrash
+//! re-arms the held lock and the shmem reset walk restores the boot image.
+//!
+//! Own test binary (process-global shmem, like crash_restart.rs, whose
+//! harness this clones; that test pins the orchestration with a fabricated
+//! exit and hand-tampered state — this one drives the state through a real
+//! unwind).
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc::channel;
+
+use postmaster::{with_pm, PMState, StartupStatusEnum};
+use types_core::init::BackendType;
+
+static SIGQUIT_SEEN: AtomicBool = AtomicBool::new(false);
+
+fn observe_sigquit() {
+    SIGQUIT_SEEN.store(true, Ordering::SeqCst);
+}
+
+fn write_valid_control_file(dir: &str) {
+    std::fs::create_dir_all(format!("{dir}/global")).unwrap();
+    std::fs::write(format!("{dir}/global/pg_control"), []).unwrap();
+    let mut cf = controldata_utils::ControlFileData::ZEROED;
+    cf.pg_control_version = controldata_utils::PG_CONTROL_VERSION;
+    cf.catalog_version_no = controldata_utils::CATALOG_VERSION_NO;
+    cf.maxAlign = 8;
+    cf.floatFormat = 1234567.0;
+    cf.blcksz = types_core::BLCKSZ as u32;
+    cf.relseg_size = types_storage::smgr::RELSEG_SIZE;
+    cf.xlog_blcksz = transam_xlog::XLOG_BLCKSZ as u32;
+    cf.xlog_seg_size = 16 * 1024 * 1024;
+    cf.nameDataLen = types_core::NAMEDATALEN as u32;
+    cf.indexMaxKeys = types_core::INDEX_MAX_KEYS as u32;
+    cf.toast_max_chunk_size = 1996;
+    cf.loblksize = types_storage::large_object::LOBLKSIZE as u32;
+    cf.float8ByVal = true;
+    controldata_utils::update_controlfile(dir, &mut cf, false).unwrap();
+}
+
+const VICTIM_PID: i32 = 9101;
+const SIBLING_PID: i32 = 9102;
+
+#[test]
+fn panic_under_lwlock_mid_mutation_reinits_clean() {
+    guc_tables::init_seams();
+    init_small::init_seams();
+    transam_xlog::init_seams();
+    shmem::init_seams();
+    ipc::init_seams();
+    ipci::init_seams();
+    pmchild::init_seams();
+    postmaster::init_seams();
+    pgstat::init_seams();
+    pg_prng::init_seams();
+    s_lock_seams::perform_spin_delay::set(|_| std::thread::yield_now());
+    s_lock_seams::finish_spin_delay::set(|_| {});
+    pg_sema_seams::pg_semaphore_create::set(|_| {});
+    xact_seams::is_in_parallel_mode::set(|| false);
+    xact_seams::get_current_transaction_nest_level::set(|| 1);
+    scalar_seams::parse_bool::set(|value| match value {
+        "on" | "true" | "yes" | "1" => Some(true),
+        "off" | "false" | "no" | "0" => Some(false),
+        _ => None,
+    });
+    aclchk_seams::pg_parameter_aclcheck_set::set(|_, _| Ok(true));
+    mbutils_seams::get_database_encoding::set(|| 6);
+    file_seams::with_allocated_dir::set(|dirname, cb| {
+        let mut ret = false;
+        let Ok(entries) = std::fs::read_dir(dirname) else { return Ok(false) };
+        for entry in entries {
+            ret = cb(entry.unwrap().file_name().to_str().unwrap())?;
+            if ret {
+                break;
+            }
+        }
+        Ok(ret)
+    });
+    backend_status_seams::backend_status_shmem_size::set(|| Ok(4096));
+    backend_status_seams::backend_status_shmem_init::set(|| Ok(()));
+    backend_status_seams::backend_status_shmem_reset_after_crash::set(|| {});
+    {
+        use std::sync::atomic::AtomicI32;
+        use std::sync::atomic::Ordering::Relaxed;
+        static AV_SLOTS: AtomicI32 = AtomicI32::new(16);
+        static WAL_SENDERS: AtomicI32 = AtomicI32::new(10);
+        static MAX_PREPARED: AtomicI32 = AtomicI32::new(0);
+        static MAX_LOCKS: AtomicI32 = AtomicI32::new(64);
+        guc_tables::vars::autovacuum_worker_slots.install(guc_tables::GucVarAccessors {
+            get: || AV_SLOTS.load(Relaxed),
+            set: |v| AV_SLOTS.store(v, Relaxed),
+        });
+        guc_tables::vars::max_wal_senders.install(guc_tables::GucVarAccessors {
+            get: || WAL_SENDERS.load(Relaxed),
+            set: |v| WAL_SENDERS.store(v, Relaxed),
+        });
+        guc_tables::vars::max_prepared_xacts.install(guc_tables::GucVarAccessors {
+            get: || MAX_PREPARED.load(Relaxed),
+            set: |v| MAX_PREPARED.store(v, Relaxed),
+        });
+        guc_tables::vars::max_locks_per_xact.install(guc_tables::GucVarAccessors {
+            get: || MAX_LOCKS.load(Relaxed),
+            set: |v| MAX_LOCKS.store(v, Relaxed),
+        });
+    }
+    aio_core::init_seams();
+    guc_tables::vars::io_max_combine_limit.install_if_absent(guc_tables::GucVarAccessors {
+        get: || 16,
+        set: |_| {},
+    });
+    guc::store::initialize_guc_options().unwrap();
+    pg_prng::global_prng(|prng| prng.seed(43));
+
+    init_small::globals::SetIsPostmasterEnvironment(true);
+    init_small::globals::SetMaxConnections(10);
+    init_small::globals::set_max_worker_processes(8);
+    init_small::globals::SetNBuffers(16);
+    init_small::globals::SetMaxBackends(
+        10 + 16 + 8 + 10 + types_storage::storage::NUM_SPECIAL_WORKER_PROCS,
+    );
+    pmchild_seams::init_postmaster_child_slots::call();
+    bgworker::BackgroundWorkerShmemInit();
+
+    let dir = std::env::temp_dir().join(format!("pgrust-crash-torn-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    let dir: &'static str = Box::leak(dir.to_str().unwrap().to_string().into_boxed_str());
+    write_valid_control_file(dir);
+    init_small::globals::SetDataDir(dir);
+
+    ipci_seams::create_shared_memory_and_semaphores::call(1).unwrap();
+    guc_tables::vars::remove_temp_files_after_crash.write(false);
+
+    waiteventset::InitializeWaitEventSupport().unwrap();
+    miscinit::InitProcessLocalLatch();
+
+    let victim_slot =
+        pmchild_seams::assign_postmaster_child_slot::call(BackendType::Backend).unwrap();
+    pmchild_seams::set_child_pid::call(victim_slot, VICTIM_PID);
+    let sibling_slot =
+        pmchild_seams::assign_postmaster_child_slot::call(BackendType::Backend).unwrap();
+    pmchild_seams::set_child_pid::call(sibling_slot, SIBLING_PID);
+
+    // Sibling backend: parks at its quickdie observation point.
+    let (ready_tx, ready_rx) = channel();
+    let (announce_tx, announce_rx) = channel::<()>();
+    let sibling = std::thread::spawn(move || {
+        init_small::globals::SetIsUnderPostmaster(true);
+        init_small::globals::SetMyProcNumber(1);
+        init_small::globals::SetMyProcPid(SIBLING_PID);
+        procsignal::ProcSignalInit(&[]).unwrap();
+        procsignal::pqsignal_thread(
+            libc::SIGQUIT,
+            procsignal::ThreadSignalHandler::Simple(observe_sigquit),
+        );
+        ready_tx.send(()).unwrap();
+        while !SIGQUIT_SEEN.load(Ordering::SeqCst) {
+            procsignal::DrainThreadSignals().unwrap();
+            std::thread::yield_now();
+        }
+        announce_rx.recv().unwrap();
+        postmaster_seams::announce_child_exit::call(SIBLING_PID, 2 << 8);
+    });
+    ready_rx.recv().unwrap();
+
+    with_pm(|pm| {
+        pm.pm_state = PMState::PM_RUN;
+        pm.conns_allowed = true;
+    });
+
+    // Victim backend: a REAL panic while HOLDING an LWLock, mid-mutation of
+    // shared transam state. The unwind is caught (launch_backend's
+    // catch_unwind contract) and translated into the synthetic crash-exit
+    // announcement, exactly as the production wrapper does for the
+    // catchable class.
+    let lock0 = lwlock::main_lock(0);
+    let victim = std::thread::spawn(move || {
+        init_small::globals::SetIsUnderPostmaster(true);
+        init_small::globals::SetMyProcNumber(0);
+        init_small::globals::SetMyProcPid(VICTIM_PID);
+        let unwound = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            lwlock::LWLockAcquire(lwlock::main_lock(0), lwlock::LW_EXCLUSIVE, 0).unwrap();
+            // Half-applied shared mutation: the "torn" state at fault time.
+            varsup::TransamVariables().nextOid.store(777, Ordering::Relaxed);
+            panic!("torn-state crash: panic while holding an LWLock mid-mutation");
+        }));
+        assert!(unwound.is_err());
+        postmaster_seams::announce_child_exit::call(VICTIM_PID, libc::SIGABRT);
+    });
+    victim.join().unwrap();
+
+    // The torn state is real: C-style locking releases nothing on unwind,
+    // and the mutation stuck. This is what the ladder must clear.
+    assert_ne!(
+        lock0.state.load(Ordering::Relaxed) & lwlock::LW_VAL_EXCLUSIVE,
+        0,
+        "the unwind must have left the LWLock held (no RAII release)"
+    );
+    assert_eq!(varsup::TransamVariables().nextOid.load(Ordering::Relaxed), 777);
+
+    // Crash choreography: fatal fan-out, sibling quiesce, reinit ladder.
+    postmaster::process_pm_child_exit().unwrap();
+    assert!(with_pm(|pm| pm.fatal_error), "HandleFatalError must set fatal_error");
+    assert_eq!(with_pm(|pm| pm.pm_state), PMState::PM_WAIT_BACKENDS);
+
+    announce_tx.send(()).unwrap();
+    sibling.join().unwrap();
+    assert!(SIGQUIT_SEEN.load(Ordering::SeqCst), "sibling must observe SIGQUIT");
+
+    postmaster::process_pm_child_exit().unwrap();
+
+    // Post-reinit: the held lock is re-armed, the torn mutation is gone.
+    assert_eq!(
+        lock0.state.load(Ordering::Relaxed),
+        lwlock::LW_FLAG_RELEASE_OK,
+        "LWLockResetAfterCrash must clear the crash-held exclusive bit"
+    );
+    assert_eq!(
+        varsup::TransamVariables().nextOid.load(Ordering::Relaxed),
+        0,
+        "the shmem reset walk must restore the boot image over the torn store"
+    );
+    assert_eq!(with_pm(|pm| pm.pm_state), PMState::PM_STARTUP);
+    assert!(with_pm(|pm| pm.startup.is_some()));
+    assert_eq!(with_pm(|pm| pm.startup_status), StartupStatusEnum::Running);
+
+    // And the lock is USABLE again, not just bit-reset: a fresh
+    // acquire/release cycle from this thread succeeds.
+    lwlock::LWLockAcquire(lock0, lwlock::LW_EXCLUSIVE, 0).unwrap();
+    lwlock::LWLockRelease(lock0).unwrap();
+    assert_eq!(lock0.state.load(Ordering::Relaxed), lwlock::LW_FLAG_RELEASE_OK);
+}

--- a/docs/crash-isolation.md
+++ b/docs/crash-isolation.md
@@ -1,0 +1,109 @@
+# Crash isolation under thread-per-backend
+
+pgrust runs one OS thread per backend inside a single process, where C
+PostgreSQL forks one process per backend. That choice changes the crash
+isolation contract, and the difference is deliberate, bounded, and — for one
+crash class — strictly weaker than C's. This document states the contract
+explicitly so operators and contributors don't have to reverse-engineer it
+from `launch_backend`, `postmaster/statemachine.rs`, and `crash_signals.rs`.
+(Raised as upstream issue #67.)
+
+## The C baseline
+
+When a C backend dies abnormally, the postmaster — a separate process whose
+private memory the backend could never touch — reaps it via `SIGCHLD`,
+assumes shared memory *may* be corrupt, `SIGQUIT`s every other child
+(`quickdie`: no cleanup, by design), waits for quiescence, discards and
+rebuilds shared memory, and restarts. Two properties do the heavy lifting:
+
+1. **The supervisor survives by construction.** No backend fault can touch
+   the postmaster's address space.
+2. **The blast radius is exactly shared memory.** A crashing backend can
+   have torn only shared structures; those are unconditionally rebuilt, and
+   sibling *private* memory was never reachable.
+
+## pgrust's two crash classes
+
+### 1. Caught panics (the catchable class) — C-equivalent choreography
+
+Every backend thread body runs under `std::panic::catch_unwind`
+(`launch_backend`). A panic — `unwrap()`, assertion, explicit `panic!`,
+including every "unported path" named panic — unwinds to the wrapper, which
+translates it into a synthetic crash-exit announcement. The postmaster
+thread then runs the same ladder C does: `HandleFatalError` marks the
+fatal state, `SIGQUIT`s every other backend thread (which observe it at
+their quickdie-equivalent points and exit without cleanup), waits for
+quiescence, and runs the reinit walk — `shmem_exit(1)`,
+`ipci::ResetShmemAfterCrash` (every shared structure back to its boot
+image: LWLocks re-armed, transam variables re-seeded, proc arrays and
+buffer state reset), `BackgroundWorkerShmemInit` — before re-entering
+`PM_STARTUP` with a fresh startup child driving crash recovery from WAL.
+
+Because locking is C-style (no RAII guards), a panicking thread releases
+nothing on unwind: LWLocks stay held, half-applied mutations stay torn.
+That is the same state C's `quickdie` leaves behind, and the same answer
+applies — nothing consults the torn state before the reset walk rebuilds
+it. The postmaster thread itself takes no LWLocks during the choreography,
+so a crash-held lock cannot deadlock the ladder.
+
+Tested (both in `postmaster/tests/`):
+
+- `crash_restart.rs` — the orchestration: fan-out, quiesce reason,
+  reset walk, `PM_STARTUP` re-entry, fresh startup child.
+- `crash_restart_torn.rs` — the torn-state arm this document exists for:
+  a real panic unwinds a backend thread while it **holds an LWLock
+  mid-mutation of shared transam state**; the test proves the unwind
+  released nothing (the tear is real), then that the ladder clears both
+  the crash-held lock and the torn store, and that the lock is usable
+  again after reinit.
+
+**The honest limit of this class**: the choreography assumes the panic's
+*cause* was logical, not memory unsafety. Between the panic and sibling
+quiesce there is a window where other threads still run against shared
+structures the victim may have left mid-mutation — identical in kind to
+C's window between a child crash and `SIGQUIT` delivery, but wider in
+scope, because here *all* memory is shared-fault-domain, not just shmem.
+Structures are designed so that torn-but-unconsulted state is safe (locks
+gate readers; the reset walk rebuilds before reuse), but this is an
+invariant maintained by discipline, not enforced by the type system.
+
+### 2. Fatal signals (SIGSEGV / SIGBUS / SIGILL / SIGABRT) — process-fatal by design
+
+A genuine memory-safety violation (a bug in `unsafe` code, a wild write, a
+stack overflow) raises a fatal signal, and **backends are threads: the
+signal kills the whole server**. `crash_signals.rs` emulates C's
+"terminated by signal N" log line, restores the previous disposition, and
+re-raises. It does not — structurally cannot — run the reinit ladder: the
+process that would run it is the process that is dying.
+
+This is the deliberately weaker half of the contract:
+
+- **C**: postmaster survives, resets, restarts children. Self-healing.
+- **pgrust**: the server exits. Recovery is a fresh process start —
+  **an external supervisor (systemd `Restart=`, a container restart
+  policy, an orchestrator) is a required part of a production
+  deployment**, not an optional nicety. Durability is unaffected (crash
+  recovery replays WAL exactly as after a power cut); availability
+  depends on the supervisor's restart latency.
+
+There is an argument this is the *safer* rendering of that crash class:
+after UB has demonstrably occurred in a shared address space, resetting
+shmem-shaped structures and continuing (as C does after a child SIGSEGV)
+trusts that the corruption stopped at a boundary the dying process can no
+longer vouch for. pgrust instead abandons the whole address space. The
+cost is availability; the benefit is never running on memory a UB event
+may have poisoned.
+
+## Operator summary
+
+| event | what happens | what you must provide |
+|---|---|---|
+| backend panic (assert, unported path, OOM-as-error) | in-process restart: SIGQUIT fan-out, shmem reset, WAL crash recovery | nothing |
+| SIGSEGV/SIGBUS/SIGILL/SIGABRT anywhere | log line, whole-process death, core per disposition | an external supervisor that restarts the binary |
+
+## Prior art
+
+The trade-off is the classic multi-threaded-PostgreSQL question; see the
+pgconf.eu 2023 session "Multi-threaded PostgreSQL" and the pgsql-hackers
+thread `31cc6df9-53fe-3cd9-af5b-ac0d801163f4@iki.fi` (both linked from
+issue #67).


### PR DESCRIPTION
Addresses #67 — the two concrete hardening items the issue suggests (the contract doc and the torn-state test). The broader architectural question stays open for the discussion @malisper mentioned; this PR just makes the current contract explicit and tested.

## 1. `docs/crash-isolation.md` (+ a GOAL.md pointer)

States the thread-per-backend crash contract explicitly, per crash class:

- **Caught panics**: C-equivalent choreography in-process — `catch_unwind` → synthetic crash exit → `HandleFatalError` fan-out → quiesce → full shmem reset walk → `PM_STARTUP` with WAL crash recovery. Includes the honest torn-state reasoning: C-style locking releases nothing on unwind, which is the same state C's `quickdie` leaves; nothing consults torn structures before the reset walk rebuilds them, and the postmaster thread takes no LWLocks during the ladder — plus the honest limit (the pre-quiesce window spans the whole address space here, not just shmem, and the invariant is discipline, not types).
- **Fatal signals** (SIGSEGV/SIGBUS/SIGILL/SIGABRT): whole-server death **by design**; `crash_signals.rs` logs C's "terminated by signal N" line and re-raises. **An external supervisor is a required part of a production deployment.** The doc also gives the counter-argument for why abandoning the address space after demonstrated UB is arguably safer than C's reset-and-continue.
- An operator summary table, and the prior-art links from the issue thread.

(This starts the `docs/` tree — the paths referenced from code comments were never committed.)

## 2. `postmaster/tests/crash_restart_torn.rs`

The untested gap the issue identified: `crash_restart.rs` fabricates the crash from the test's own thread with no lock held. The new test (own binary — process-global shmem) drives the state through a **real unwind**:

- a victim backend thread takes `main_lock(0)` exclusively, half-applies a shared transam mutation (`nextOid = 777`), and panics inside `catch_unwind`, then announces the synthetic crash exit from its own thread — the production wrapper's exact contract;
- **the tear is proven real before recovery runs**: the exclusive bit is still set after the join (no RAII release) and the half-applied store stuck;
- after the fan-out (sibling observes SIGQUIT at its quickdie point) and the reinit ladder: the crash-held lock is re-armed to `LW_FLAG_RELEASE_OK`, the torn store is back at the boot image, `PM_STARTUP` is re-entered with a live startup child — and the lock is **usable**, not just bit-reset (a fresh acquire/release cycle succeeds).

## Verification

- Both crash tests green in the container (Ubuntu 26.04, rustc 1.96.0).
- The new test passing first-try is the issue's hoped-for outcome (its option "a": the ladder already produces a clean post-restart state) — so its teeth were proven by mutation: commenting out `LWLockResetAfterCrash`'s state store makes it fail with exactly `LWLockResetAfterCrash must clear the crash-held exclusive bit`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance on crash isolation in thread-per-backend deployments.
  * Documented how recoverable backend panics are handled through in-process shutdown, shared-state reset, and restart.
  * Clarified that memory-safety failures terminate the server and require an external supervisor to restart it.
  * Added operational requirements, limitations, and recovery behavior for administrators.

* **Reliability**
  * Added coverage validating recovery after a backend crash during shared-state updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->