### PR TITLE
xlogrecovery: drain prefetch pins after the redo loop (fixes DROP TABLE spinning forever after crash recovery)

### DIFF
--- a/crates/backend/access/transam/xlogrecovery/src/lib.rs
+++ b/crates/backend/access/transam/xlogrecovery/src/lib.rs
@@ -1927,6 +1927,15 @@ fn perform_wal_recovery_guts(rec: &mut Recovery) -> PgResult<()> {
             have_record = read_record(rec, LOG, false, replay_tli)?;
         }
 
+        // The WAL prefetcher issues io_uring reads whose buffer pins are owned
+        // by this thread's ring slots and are only dropped when this thread
+        // collects them (bufmgr::uring::start_read -> collect_done). Redo has
+        // no further prefetch after the last record, so wait out and collect
+        // the in-flight reads here; otherwise the last prefetched page stays
+        // pinned forever and DropRelationsAllBuffers (DROP TABLE, TRUNCATE,
+        // DROP DATABASE) on that relation spins in InvalidateBuffer.
+        bufmgr::uring_drain_pins();
+
         if reached_recovery_target {
             if !reached_consistency() {
                 ereport(FATAL)


### PR DESCRIPTION
Fixes #93.

## Problem

After a crash (`kill -9`) and successful WAL recovery, `DROP TABLE` on a relation whose pages were replayed by redo never returns: the transaction commits, then the backend thread spins at 100% CPU forever in `bufmgr::drop_buffers::InvalidateBuffer`, and `pg_cancel_backend` has no effect. Full analysis, stack traces and `pg_buffercache` evidence are in #93.

## Root cause

The WAL prefetcher issues io_uring reads through `PrefetchSharedBuffer -> uring::start_read`. `start_read` pins the victim buffer and hands the pin to the issuing thread's ring slot (`ForgetBufferPin`); the pin is only dropped when that same thread runs `collect_done` (called at the start of the *next* `start_read`) or `drain_own`.

Redo issues no further prefetch after the last record, and nothing on the startup thread drains its ring at the end of recovery, so the pin on the last prefetched page is stranded. `pg_buffercache` shows exactly one buffer of the relation (its last block) with `pinning_backends = 1` on an idle server after recovery.

`InvalidateBuffer` then sees shared refcount != 0, private refcount == 0 and no IO in progress, so `WaitIO` returns immediately and the `continue` loop never terminates.

## Fix

Call `bufmgr::uring_drain_pins()` once the redo loop in `perform_wal_recovery_guts` ends. This is the same collect/drain discipline already used by `AtEOXact_Buffers`, `LockBufferForCleanup` and pool-worker ring teardown; the recovery path was the one place that issued prefetch reads without ever collecting them.

## Verification (x86_64, Ubuntu 24.04, `io_method=sync`, default `recovery_prefetch=try`)

| Scenario | Before | After |
|---|---|---|
| insert 100k rows, `kill -9`, restart, `DROP TABLE` | spins forever | 0.02-0.04 s (3/3 runs) |
| `pg_buffercache` pinned buffers of the relation after recovery, idle server | 1 | 0 |
| insert, `CHECKPOINT`, `kill -9`, restart, `DROP` | ok | ok |
| empty table, `kill -9`, restart, `DROP` | ok | ok |
| clean shutdown, restart, `DROP` | ok | ok |
| `cargo test --release -p xlogrecovery -p bufmgr` | pass | pass |
| basic SQL smoke test (DDL/DML/index/txn/JSONB/regex/CTE) | ok | ok |

Setting `recovery_prefetch=off` also avoids the bug on the unpatched build, which independently confirms the prefetcher as the source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WAL recovery cleanup by ensuring in-flight prefetch operations are completed before recovery proceeds.
  * Helps prevent lingering resources after WAL replay finishes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->