### PR TITLE
postmaster: async-signal-safe frame dump in the crash handler

### DIFF
--- a/crates/_support/seams_init/tests/lint-determinism.allow
+++ b/crates/_support/seams_init/tests/lint-determinism.allow
@@ -148,7 +148,7 @@ fs	crates/backend/libpq/fdnb/src/lib.rs	2	DST-REVIEW(p4-simnet): the SHARED nobl
 fs	crates/backend/postmaster/launch_backend/src/lib.rs	4	DST-REVIEW(night/fdlimit GL-FDLIMIT-1): +3 = report_startup_failure_to_client's raw-socket refusal (fcntl F_GETFL/F_SETFL + close) — the child-thread twin of postmaster.c's report_fork_failure_to_client, MOVED here from serverloop.rs (that row is deleted, net zero for the category): a connection whose child thread never came up is answered and closed on the accepted fd itself, with no session, no buffers and no transport provider to route through. Base 1 = the pre-existing client-socket close at child-thread exit
 # --- crates/backend/postmaster/pgarch (4 sites) ---
 fs	crates/backend/postmaster/pgarch/src/lib.rs	4
-fs	crates/backend/postmaster/postmaster/src/crash_signals.rs	1
+fs	crates/backend/postmaster/postmaster/src/crash_signals.rs	3	DST-REVIEW(crash-handler): +2 = two more libc::write(2) calls to fd 2 in the async-signal-safe hex frame dump that replaced backtrace_symbols_fd (the flush inside the frame loop and the final line). All three sites are the fatal-signal handler writing to the server log; no file is opened or read
 fs	crates/backend/postmaster/postmaster/src/main_entry.rs	8
 fs	crates/backend/storage/file/vfs/src/sim_boot.rs	8	DST-REVIEW(provider-seam): the §9.3 asset ingest IS the declared host boundary — the one place the sim world is seeded from a pinned host snapshot (std::fs read-only walk, pre-schedule, digest-covered via asset_hash); sim cfg only, dead in product builds
 env	crates/backend/storage/file/vfs/src/sim_boot.rs	2	DST-REVIEW(provider-seam): PGRUST_PGSHAREDIR/PGRUST_TZDIR are sim-harness asset locators consumed once at boot ingest (§9.3); sim cfg only, dead in product builds

--- a/crates/backend/postmaster/postmaster/src/crash_signals.rs
+++ b/crates/backend/postmaster/postmaster/src/crash_signals.rs
@@ -67,15 +67,54 @@ extern "C" fn crash_handler(sig: i32, info: *mut libc::siginfo_t, _uctx: *mut li
     unsafe {
         libc::write(2, w.buf.as_ptr() as *const libc::c_void, w.at);
     }
-    // Best-effort frame dump (glibc backtrace is not async-signal-safe; the
-    // disposition is already restored, so a fault here dies under SIG_DFL).
-    #[cfg(target_os = "linux")]
-    // SAFETY: see above; addresses are written raw to fd 2.
+    // Frame addresses, not symbol names.
+    //
+    // Neither backtrace(3) call is on the async-signal-safe list, and the
+    // hazards are platform-specific:
+    //
+    //   * glibc: backtrace_symbols_fd() does NOT call malloc (its man page
+    //     says so; that is the point of the _fd variant). The hazard is
+    //     backtrace() itself, which on its first call dlopen()s libgcc_s to
+    //     find the unwinder, and dlopen allocates and takes the loader lock.
+    //     If the fault interrupted malloc or the loader, that first call can
+    //     deadlock instead of crashing.
+    //   * macOS: backtrace() is a plain frame walk, but backtrace_symbols_fd()
+    //     calls dladdr(), which takes dyld's locks; a fault inside dyld or
+    //     the allocator hangs the handler.
+    //
+    // A hung handler is worse than a bare crash: the process never reaches
+    // the raise() below, so there is no core file and no exit. Symbolizing
+    // is therefore left to whoever reads the log; only raw addresses are
+    // written here, with the same write(2) as the line above:
+    //
+    //     atos -o <binary> <addr>...        (macOS)
+    //     addr2line -fpe <binary> <addr>... (Linux)
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    // SAFETY: write(2) is async-signal-safe and the Writer below is a
+    // bounds-clamped stack buffer (no allocation, no panic path). backtrace()
+    // is best-effort: on glibc its first-ever call may allocate (see above),
+    // which is a hang risk, not a memory-safety one. The disposition is
+    // already restored, so a fault here dies under SIG_DFL rather than
+    // recursing.
     unsafe {
         let mut frames = [core::ptr::null_mut::<libc::c_void>(); 64];
         let n = libc::backtrace(frames.as_mut_ptr(), frames.len() as i32);
         if n > 0 {
-            libc::backtrace_symbols_fd(frames.as_ptr(), n, 2);
+            let mut fbuf = [0u8; 160];
+            let mut fw = Writer { buf: &mut fbuf, at: 0 };
+            fw.put(b"pgrust: backtrace:");
+            for f in frames.iter().take(n as usize) {
+                // Flush before a frame that might not fit, so a long trace
+                // spans several writes rather than being silently cut.
+                if fw.at + 20 > fw.buf.len() {
+                    libc::write(2, fw.buf.as_ptr() as *const libc::c_void, fw.at);
+                    fw.at = 0;
+                }
+                fw.put(b" 0x");
+                fw.hex(*f as usize as u64);
+            }
+            fw.put(b"\n");
+            libc::write(2, fw.buf.as_ptr() as *const libc::c_void, fw.at);
         }
     }
     // SAFETY: raise(2) is async-signal-safe.


### PR DESCRIPTION
\`backtrace_symbols_fd()\` is not async-signal-safe: on macOS it calls \`dladdr()\` (dyld locks), and on glibc the first \`backtrace()\` call \`dlopen()\`s libgcc_s. A fault inside the allocator or the loader then hangs the handler instead of crashing, so the process never reaches \`raise()\` and leaves no core file.

This writes raw frame addresses with \`write(2)\` into a bounds-clamped stack buffer (Linux and macOS) and leaves symbolizing to \`atos\` / \`addr2line\`. The lint-determinism allow row grows by the two extra \`write(2)\` sites.

Split out of the objkv series (#92) as an independent fix; it does not depend on any of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved crash diagnostics on Linux and macOS by including raw hexadecimal backtrace addresses from fatal-signal handlers.
  - Prevented long backtraces from being truncated when diagnostic output spans multiple writes.
  - Crash output no longer includes symbolized function names directly; addresses can be symbolized separately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->