### PR TITLE
session: re-derive the TLS census pin at main's tip (544 -> 545)

### DIFF
--- a/crates/backend/access/session/src/tests.rs
+++ b/crates/backend/access/session/src/tests.rs
@@ -809,7 +809,11 @@ fn tls_source_census_and_session_surface_are_pinned() {
     // NOTE for whoever merges this to main: the same one declaration lands on a
     // DIFFERENT absolute total there (562 -> 563 at t56). Re-derive the pin at
     // the tip it will be enforced against; do not carry this number across.
-    assert_eq!(count_tree(crates), 544, "TLS census changed; classify the delta in SESSION_ENVELOPE_MANIFEST or document it as non-session TLS");
+    // Re-derived at main's tip, as the NOTE above asks: the pin carried the
+    // donor branch's total and lagged this tree by one (544 -> 545). No
+    // thread_local! declaration has changed since bcda79e; the count there
+    // was already 545.
+    assert_eq!(count_tree(crates), 545, "TLS census changed; classify the delta in SESSION_ENVELOPE_MANIFEST or document it as non-session TLS");
     let session_sources = [
         ("backend/access/session/src/lib.rs", 1),
         ("backend/utils/init/init_small/src/globals.rs", 4),


### PR DESCRIPTION
\`tls_source_census_and_session_surface_are_pinned\` fails on main: the tree has 545 \`thread_local!\` declarations and the pin says 544. The comment above the pin already warns that the number was carried from a donor branch and must be re-derived at the tip it is enforced against; this does that. No declaration has changed since bcda79e.

Independent of the objkv series, but objkv/3 (table AM) re-pins the same line at 552, so whichever lands second needs a one-line rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated the TLS census test expectation to reflect the current count.
  * Revised the associated test comment to document the updated baseline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->