### PR TITLE
objkv 1/6: object-store client, run format, key encodings, lease

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1904,9 +1904,9 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.21.7"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64"
@@ -4792,9 +4792,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-mac"
-version = "0.10.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bff07008ec701e8028e2ceb8f83f0e4274ee62bd2dbdc4fefff2e9a91824081a"
+checksum = "4857fd85a0c34b3c3297875b747c1e02e06b6a0ea32dd892d8192b9ce0813ea6"
 dependencies = [
  "generic-array",
  "subtle",
@@ -10757,6 +10757,7 @@ version = "0.0.0"
 dependencies = [
  "crc32c",
  "libc",
+ "pg_clock",
  "pgsync",
  "rusty-s3",
  "ureq",
@@ -15900,44 +15901,58 @@ checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rustls"
-version = "0.21.12"
+version = "0.23.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
 dependencies = [
  "log",
+ "once_cell",
  "ring",
+ "rustls-pki-types",
  "rustls-webpki",
- "sct",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.6.3"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
+checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
 dependencies = [
  "openssl-probe",
  "rustls-pemfile",
+ "rustls-pki-types",
  "schannel",
  "security-framework",
 ]
 
 [[package]]
 name = "rustls-pemfile"
-version = "1.0.4"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
 dependencies = [
- "base64 0.21.7",
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
+dependencies = [
+ "zeroize",
 ]
 
 [[package]]
 name = "rustls-webpki"
-version = "0.101.7"
+version = "0.103.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+checksum = "f3c3cf1d8b1e7d4927e2d154c3fcb02979afb9939629c62cd9048d4f07b60ac2"
 dependencies = [
  "ring",
+ "rustls-pki-types",
  "untrusted",
 ]
 
@@ -16078,16 +16093,6 @@ dependencies = [
  "pg_sha2",
  "postgres_seams",
  "types_error",
-]
-
-[[package]]
-name = "sct"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
-dependencies = [
- "ring",
- "untrusted",
 ]
 
 [[package]]
@@ -17922,9 +17927,9 @@ dependencies = [
 
 [[package]]
 name = "subtle"
-version = "2.4.1"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "subtrans"
@@ -19904,18 +19909,18 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "ureq"
-version = "2.9.1"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8cdd25c339e200129fe4de81451814e5228c9b771d57378817d6117cc2b3f97"
+checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.22.1",
  "log",
  "once_cell",
  "rustls",
  "rustls-native-certs",
- "rustls-webpki",
+ "rustls-pki-types",
  "url",
- "webpki-roots",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -20770,9 +20775,21 @@ version = "0.1.0"
 
 [[package]]
 name = "webpki-roots"
-version = "0.25.4"
+version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.9",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
+dependencies = [
+ "rustls-pki-types",
+]
 
 [[package]]
 name = "windows-link"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1186,7 +1186,7 @@ checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher 0.4.4",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -1903,6 +1903,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "base64"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
+
+[[package]]
 name = "basebackup"
 version = "0.0.0"
 dependencies = [
@@ -2165,6 +2177,12 @@ version = "0.1.0"
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
@@ -2188,6 +2206,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -3264,7 +3291,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "inout",
 ]
 
@@ -3392,6 +3419,12 @@ dependencies = [
  "types_core",
  "types_portal",
 ]
+
+[[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "coerce"
@@ -4422,6 +4455,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "contrib_cube"
 version = "0.0.0"
 dependencies = [
@@ -4639,6 +4678,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
 name = "costsize"
 version = "0.1.0"
 dependencies = [
@@ -4669,6 +4724,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca28b0ae3115b884660db4118d803791fd6756b6e88f39c0f3f7859060d7566"
 dependencies = [
  "libc",
 ]
@@ -4718,6 +4782,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "crypto-mac"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4739,6 +4812,15 @@ dependencies = [
  "types_error",
  "types_fmgr",
  "varlena",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
 ]
 
 [[package]]
@@ -4951,6 +5033,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "defmt"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2953bfe4f93bbd20cc71198842756f77d161884c99ebbabc41d80231ded88d1"
+dependencies = [
+ "bitflags 1.3.2",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad9c72e7ca2137e0dc3813245a0d282fd6daad32fd800af018306a9169b5fe8"
+dependencies = [
+ "defmt-parser",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror",
+]
+
+[[package]]
 name = "dependency_seams"
 version = "0.0.0"
 dependencies = [
@@ -5027,6 +5140,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "const-oid",
+ "crypto-common 0.2.2",
+ "ctutils",
+]
+
+[[package]]
 name = "discard"
 version = "0.1.0"
 dependencies = [
@@ -5043,6 +5168,17 @@ dependencies = [
  "types_nodes",
  "types_storage",
  "xact",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -6223,6 +6359,15 @@ dependencies = [
  "types_error",
  "types_fmgr",
  "types_nodes",
+]
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
 ]
 
 [[package]]
@@ -7501,13 +7646,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "hmac"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1441c6b1e930e2817404b5046f1f989899143a12bf92de603b69f4e0aee1e15"
 dependencies = [
  "crypto-mac",
- "digest",
+ "digest 0.9.0",
+]
+
+[[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -7555,8 +7715,121 @@ dependencies = [
 ]
 
 [[package]]
+name = "hybrid-array"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
 name = "hyperloglog"
 version = "0.1.0"
+
+[[package]]
+name = "icu_collections"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa68d21081c4a05d5a901a1c62add574c77048b6a1c67be3b50ce0b60d4ca513"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d56e28588da92eee5c3201a6eff33fabdd49b62269c8938d4ff050ce4d900deb"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f9cf5f235641ed274641dd81c3f28d870e276763d0797aeeab72317b1c646f"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1563da1ed3e0b3bf3d74c9b85917ac9c56464d2f57242270c09c9e752f8021a0"
+
+[[package]]
+name = "icu_properties"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e7ca276ad3145661a65914e6daf131ca5120cd3dcee8f8f3214b8875184a148"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e590f038c1464a96894fd6d10127e90a8be4509f56ff7ecef851b15cee0b7caa"
+
+[[package]]
+name = "icu_provider"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d27bbb9d3abbefac45d55f647c9de1d44aafcd1186eb91879afef17c396c3e73"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
 
 [[package]]
 name = "ifaddr"
@@ -7798,6 +8071,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "instant-xml"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a2cad967c3b727c000ebfdcd14974539e8c6f59e1d044c8034179df2c6fe250"
+dependencies = [
+ "instant-xml-macros",
+ "thiserror",
+ "xmlparser",
+]
+
+[[package]]
+name = "instant-xml-macros"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3c2e6cbd6e0579ee53a8290fc0015a438cfff0139c8359d5891cae130815d7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 3.0.4",
+]
+
+[[package]]
 name = "instrument"
 version = "0.1.0"
 dependencies = [
@@ -8023,6 +8319,48 @@ dependencies = [
  "types_error",
  "types_fmgr",
  "types_guc",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "jiff"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "668b7183bd07af9a4885f5c35b0cc5c83c4607a913c16b7e17291832910d2dcc"
+dependencies = [
+ "defmt",
+ "jiff-core",
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+]
+
+[[package]]
+name = "jiff-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7feca88439efe53da3754500c1851dedf3cb36c524dd5cf8225cc0794de95d09"
+dependencies = [
+ "defmt",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a69dcb3a21cfb32ce1cd056169337ca284af0766dd766e7878819b251a49204"
+dependencies = [
+ "jiff-core",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -8302,6 +8640,12 @@ version = "0.0.0"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "litemap"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d9d19d1d6efa0109d2f65ff4c85cddd50bd572e5a00127ab10987290bcefae"
 
 [[package]]
 name = "lmgr"
@@ -8938,9 +9282,19 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5a279bb9607f9f53c22d496eade00d138d1bdcccd07d74650387cf94942a15"
 dependencies = [
- "block-buffer",
- "digest",
+ "block-buffer 0.9.0",
+ "digest 0.9.0",
  "opaque-debug",
+]
+
+[[package]]
+name = "md-5"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
+dependencies = [
+ "cfg-if",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -10347,7 +10701,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10395,6 +10749,17 @@ dependencies = [
  "types_error",
  "types_nodes",
  "types_rel",
+]
+
+[[package]]
+name = "objkv"
+version = "0.0.0"
+dependencies = [
+ "crc32c",
+ "libc",
+ "pgsync",
+ "rusty-s3",
+ "ureq",
 ]
 
 [[package]]
@@ -10464,7 +10829,7 @@ version = "0.10.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -10480,8 +10845,14 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-src"
@@ -11394,6 +11765,12 @@ dependencies = [
  "types_pathnodes",
  "types_tuple",
 ]
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "percentrepl"
@@ -13226,6 +13603,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "portable-atomic"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05c8b63e8d9609db387f0324918f81d68fe27748f084ef092fb35954d0539a85"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
 name = "portalcmds"
 version = "0.1.0"
 dependencies = [
@@ -13752,6 +14144,15 @@ dependencies = [
  "types_startup",
  "xlogrecovery_seams",
  "xlogutils",
+]
+
+[[package]]
+name = "potential_utf"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d83eb9bc6d8e5cf568e7a1101d60ee05e81ed50ea106026f3d18deeb046d7661"
+dependencies = [
+ "zerovec",
 ]
 
 [[package]]
@@ -14352,11 +14753,11 @@ checksum = "419a3ad8fa9f9d445e69d9b185a24878ae6e6f55c96e4512f4a0e28cd3bc5c56"
 dependencies = [
  "blowfish 0.7.0",
  "byteorder",
- "hmac",
- "md-5",
+ "hmac 0.10.1",
+ "md-5 0.9.1",
  "rand",
  "sha-1",
- "sha2",
+ "sha2 0.9.9",
 ]
 
 [[package]]
@@ -15277,6 +15678,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rls"
 version = "0.0.0"
 dependencies = [
@@ -15484,10 +15899,72 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
+name = "rustls"
+version = "0.21.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-webpki",
+ "sct",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
+dependencies = [
+ "base64 0.21.7",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.101.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
+
+[[package]]
+name = "rusty-s3"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2412ec048709e6a8ee4ee1505313bce003f6b8b27fc41a97e30615223c7ed592"
+dependencies = [
+ "base64 0.23.1",
+ "hmac 0.13.0",
+ "instant-xml",
+ "jiff",
+ "md-5 0.11.0",
+ "percent-encoding",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
+ "url",
+ "zeroize",
+]
 
 [[package]]
 name = "ryu"
@@ -15543,6 +16020,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "schemacmds"
 version = "0.1.0"
 dependencies = [
@@ -15592,6 +16078,16 @@ dependencies = [
  "pg_sha2",
  "postgres_seams",
  "types_error",
+]
+
+[[package]]
+name = "sct"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
+dependencies = [
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
@@ -15974,6 +16470,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags 2.13.0",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "sequence"
 version = "0.1.0"
 dependencies = [
@@ -16054,6 +16573,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde"
+version = "1.0.229"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.229"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.229"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.4",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.151"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
 name = "session"
 version = "0.0.0"
 dependencies = [
@@ -16093,10 +16655,10 @@ version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99cd6713db3cf16b6c84e06321e049a9b9f699826e16096d23bbcc44d15d51a6"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.9.0",
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.9.0",
  "opaque-debug",
 ]
 
@@ -16106,11 +16668,22 @@ version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.9.0",
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.9.0",
  "opaque-debug",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.1",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -17052,6 +17625,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
 name = "stack_depth"
 version = "0.0.0"
 dependencies = [
@@ -17419,6 +17998,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "sync"
 version = "0.0.0"
 dependencies = [
@@ -17513,6 +18103,17 @@ dependencies = [
  "types_core",
  "types_error",
  "types_rel",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -17967,6 +18568,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror"
+version = "2.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.4",
+]
+
+[[package]]
 name = "thread_local"
 version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -18078,6 +18699,16 @@ dependencies = [
  "seam_core",
  "types_core",
  "types_error",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1e27c91459209c2986af3dcf603a5a74a4368754ce37414f59acc971167f643"
+dependencies = [
+ "displaydoc",
+ "zerovec",
 ]
 
 [[package]]
@@ -19266,6 +19897,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "ureq"
+version = "2.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8cdd25c339e200129fe4de81451814e5228c9b771d57378817d6117cc2b3f97"
+dependencies = [
+ "base64 0.21.7",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-webpki",
+ "url",
+ "webpki-roots",
+]
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
 name = "user"
 version = "0.1.0"
 dependencies = [
@@ -19305,6 +19970,12 @@ dependencies = [
  "varlena",
  "xact",
 ]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utility"
@@ -20098,6 +20769,12 @@ name = "wchar"
 version = "0.1.0"
 
 [[package]]
+name = "webpki-roots"
+version = "0.25.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -20114,12 +20791,85 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "wparser_def"
@@ -20146,6 +20896,12 @@ dependencies = [
  "varlena",
  "wchar",
 ]
+
+[[package]]
+name = "writeable"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ad82d2a33cdc9674dc7465672f271e096168fcdbe0f799d9e6db8c5892679dc"
 
 [[package]]
 name = "xact"
@@ -20643,6 +21399,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "xmlparser"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
+
+[[package]]
+name = "yoke"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+ "synstructure",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -20659,8 +21444,74 @@ checksum = "4714fd92cf900833d49538023a9b3915155210801d1c1169eba513b2addefd71"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+ "synstructure",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ea269c3bd32f0a32c321907a2ae912ba6f4649bb0fc764a15627e99a7095a3f"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0464e17806c1d976d5cba29399c7f08e516e279e2ba493f63123b5fca67dd8"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34df6fc39dbd26ddc9c10e6a2984476e13acce22e64e4487636ef494369225da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.4",
+]
+
+[[package]]
+name = "zmij"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
 
 [[package]]
 name = "zstd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -847,6 +847,7 @@ members = [
     "crates/backend/utils/adt/waitfuncs",
     "crates/backend/utils/adt/pseudorandomfuncs",
     "crates/backend/utils/adt/pg_upgrade_support",
+    "crates/_support/objkv",
 ]
 
 [workspace.package]

--- a/crates/_support/objkv/Cargo.toml
+++ b/crates/_support/objkv/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "objkv"
+version = "0.0.0"
+edition.workspace = true
+publish.workspace = true
+
+[lib]
+name = "objkv"
+path = "src/lib.rs"
+
+[dependencies]
+pgsync = { path = "../pgsync" }
+crc32c = { path = "../../port/crc32c" }
+libc = "0.2"
+ureq = { version = "2", default-features = false, features = ["tls", "native-certs"] }
+rusty-s3 = { version = "0.10.2" }

--- a/crates/_support/objkv/Cargo.toml
+++ b/crates/_support/objkv/Cargo.toml
@@ -11,6 +11,7 @@ path = "src/lib.rs"
 [dependencies]
 pgsync = { path = "../pgsync" }
 crc32c = { path = "../../port/crc32c" }
+pg_clock = { path = "../../port/pg_clock" }
 libc = "0.2"
-ureq = { version = "2", default-features = false, features = ["tls", "native-certs"] }
+ureq = { version = "2.12", default-features = false, features = ["tls", "native-certs"] }
 rusty-s3 = { version = "0.10.2" }

--- a/crates/_support/objkv/src/bloom.rs
+++ b/crates/_support/objkv/src/bloom.rs
@@ -1,0 +1,96 @@
+//! A plain bloom filter over run keys.
+//!
+//! This is what bounds how many sorted runs a cold read has to touch. Blooms
+//! and indexes are small and stay cached locally, so a lookup consults every
+//! run's filter in memory and then issues at most one ranged GET for real data.
+//! At 10 bits per key the false-positive rate is roughly 1%.
+
+pub const BITS_PER_KEY: usize = 10;
+const HASHES: u32 = 7; // ~ BITS_PER_KEY * ln(2)
+
+fn fnv1a64(data: &[u8]) -> u64 {
+    let mut h: u64 = 0xcbf2_9ce4_8422_2325;
+    for &b in data {
+        h ^= b as u64;
+        h = h.wrapping_mul(0x1000_0000_01b3);
+    }
+    h
+}
+
+/// Kirsch-Mitzenmacher: derive k hashes from two, which is as accurate as k
+/// independent hashes for this purpose.
+fn probes(key: &[u8], bits: u64) -> impl Iterator<Item = u64> {
+    let h1 = fnv1a64(key);
+    let h2 = h1.rotate_left(31) | 1;
+    (0..HASHES).map(move |i| h1.wrapping_add((i as u64).wrapping_mul(h2)) % bits)
+}
+
+pub struct Bloom {
+    bits: Vec<u8>,
+}
+
+impl Bloom {
+    pub fn build(keys: &[&[u8]]) -> Bloom {
+        let nbits = (keys.len() * BITS_PER_KEY).max(64);
+        let mut bits = vec![0u8; nbits.div_ceil(8)];
+        let nbits = (bits.len() * 8) as u64;
+        for k in keys {
+            for p in probes(k, nbits) {
+                bits[(p / 8) as usize] |= 1 << (p % 8);
+            }
+        }
+        Bloom { bits }
+    }
+
+    pub fn from_bytes(bits: Vec<u8>) -> Bloom {
+        Bloom { bits }
+    }
+
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.bits
+    }
+
+    /// False positives are possible; false negatives are not.
+    pub fn may_contain(&self, key: &[u8]) -> bool {
+        if self.bits.is_empty() {
+            return true;
+        }
+        let nbits = (self.bits.len() * 8) as u64;
+        probes(key, nbits).all(|p| self.bits[(p / 8) as usize] & (1 << (p % 8)) != 0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn no_false_negatives() {
+        let keys: Vec<Vec<u8>> = (0..1000).map(|i| format!("key{i:06}").into_bytes()).collect();
+        let refs: Vec<&[u8]> = keys.iter().map(|k| k.as_slice()).collect();
+        let b = Bloom::build(&refs);
+        for k in &refs {
+            assert!(b.may_contain(k), "false negative is impossible");
+        }
+    }
+
+    #[test]
+    fn false_positive_rate_is_near_one_percent() {
+        let keys: Vec<Vec<u8>> = (0..2000).map(|i| format!("key{i:06}").into_bytes()).collect();
+        let refs: Vec<&[u8]> = keys.iter().map(|k| k.as_slice()).collect();
+        let b = Bloom::build(&refs);
+        let fp = (0..10_000)
+            .filter(|i| b.may_contain(format!("absent{i:06}").as_bytes()))
+            .count();
+        // Theory says ~1%; allow generous slack so this never flakes.
+        assert!(fp < 400, "false positive rate too high: {fp}/10000");
+    }
+
+    #[test]
+    fn survives_a_round_trip_through_bytes() {
+        let keys: Vec<&[u8]> = vec![b"alpha", b"beta"];
+        let b = Bloom::build(&keys);
+        let b2 = Bloom::from_bytes(b.as_bytes().to_vec());
+        assert!(b2.may_contain(b"alpha") && b2.may_contain(b"beta"));
+    }
+}

--- a/crates/_support/objkv/src/commit.rs
+++ b/crates/_support/objkv/src/commit.rs
@@ -1,0 +1,562 @@
+//! The commit object: `commit/<seq>`, one batch of writes, written once with
+//! put-if-absent. Winning that PUT is what makes the commit real, so the
+//! changeset is carried **inline** rather than referenced — one round trip,
+//! not two.
+
+use std::io;
+
+pub const MAGIC: u32 = 0x4f4b_4356; // "OKCV"
+/// Format 2 carries the writer's lease epoch where format 1 carried a
+/// `confirmed_through` watermark and a self-confirmed flag. Every object a
+/// writer produces is the commit once it lands, so nothing vouches for
+/// anything; the epoch is what lets a later open tell a stale writer's object
+/// from the owner's (see `lease.rs`). Format 1 objects are refused: a bucket
+/// written by an older objkv has to be migrated, not guessed at.
+pub const VERSION: u8 = 2;
+const HEADER_LEN: usize = 44;
+
+/// A batch object: several commits that landed in one PUT. Group commit
+/// writes these; a single commit still writes the plain form above, so an
+/// older server reads a bucket that never grouped exactly as before.
+pub const BATCH_MAGIC: u32 = 0x4f4b_4342; // "OKCB"
+pub const BATCH_VERSION: u8 = 1;
+/// magic, version, three reserved bytes, count.
+const BATCH_HEADER_LEN: usize = 4 + 1 + 3 + 4;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Op {
+    Put(Vec<u8>),
+    Delete,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Entry {
+    pub key: Vec<u8>,
+    pub op: Op,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Commit {
+    pub seq: u64,
+    /// The sorted run this commit is layered on top of; readers walk commits
+    /// back to here before consulting run files.
+    pub base_run_id: u64,
+    /// Names the writing transaction. A discard marker repeats it so the
+    /// marker can be matched to the object it judges; otherwise it is only
+    /// for the log.
+    pub xid: u32,
+    /// The lease epoch of the writer that produced this object. An object
+    /// whose epoch is below a later owner's takeover fence is a stale
+    /// writer's and is never applied.
+    pub epoch: u64,
+    pub entries: Vec<Entry>,
+}
+
+pub fn key_for(seq: u64) -> String {
+    format!("commit/{seq:016x}")
+}
+
+impl Commit {
+    pub fn encode(&self) -> Vec<u8> {
+        let mut payload = Vec::new();
+        for e in &self.entries {
+            put_u32(&mut payload, e.key.len() as u32);
+            payload.extend_from_slice(&e.key);
+            match &e.op {
+                Op::Put(v) => {
+                    payload.push(0);
+                    put_u32(&mut payload, v.len() as u32);
+                    payload.extend_from_slice(v);
+                }
+                Op::Delete => {
+                    payload.push(1);
+                    put_u32(&mut payload, 0);
+                }
+            }
+        }
+
+        let mut out = Vec::with_capacity(HEADER_LEN + payload.len() + 4);
+        put_u32(&mut out, MAGIC);
+        out.push(VERSION);
+        out.extend_from_slice(&[0, 0, 0]); // flags, reserved
+        put_u64(&mut out, self.seq);
+        put_u64(&mut out, self.base_run_id);
+        put_u32(&mut out, self.entries.len() as u32);
+        put_u32(&mut out, payload.len() as u32);
+        put_u32(&mut out, self.xid);
+        put_u64(&mut out, self.epoch);
+        debug_assert_eq!(out.len(), HEADER_LEN);
+        out.extend_from_slice(&payload);
+        let crc = crc32c::pg_comp_crc32c(0xffff_ffff, &out) ^ 0xffff_ffff;
+        put_u32(&mut out, crc);
+        out
+    }
+
+    /// `encode`, refusing anything the u32 length fields cannot describe. A
+    /// commit past 4 GiB would land with a wrong payload length and make the
+    /// bucket unopenable, so the writer checks before the PUT.
+    pub fn encode_checked(&self) -> io::Result<Vec<u8>> {
+        let too_big = |what: &str| {
+            io::Error::other(format!("objkv: commit too large to encode: {what} exceeds 4 GiB"))
+        };
+        let mut payload: u64 = 0;
+        for e in &self.entries {
+            if e.key.len() > u32::MAX as usize {
+                return Err(too_big("a key"));
+            }
+            let vlen = match &e.op {
+                Op::Put(v) => v.len(),
+                Op::Delete => 0,
+            };
+            if vlen > u32::MAX as usize {
+                return Err(too_big("a value"));
+            }
+            payload += 4 + e.key.len() as u64 + 1 + 4 + vlen as u64;
+        }
+        if self.entries.len() > u32::MAX as usize || payload > u32::MAX as u64 {
+            return Err(too_big("the payload"));
+        }
+        Ok(self.encode())
+    }
+
+    /// Never panics: length fields come off the network and may disagree with
+    /// the buffer.
+    pub fn decode(buf: &[u8]) -> io::Result<Commit> {
+        fn bad(what: &str) -> io::Error {
+            io::Error::other(format!("malformed commit object: {what}"))
+        }
+        fn take<'a>(b: &'a [u8], at: usize, n: usize) -> Option<&'a [u8]> {
+            b.get(at..at.checked_add(n)?)
+        }
+
+        if buf.len() < HEADER_LEN + 4 {
+            return Err(bad("shorter than a header"));
+        }
+        if get_u32(buf, 0) != MAGIC {
+            return Err(bad("bad magic"));
+        }
+        if buf[4] != VERSION {
+            return Err(bad(&format!(
+                "unsupported version {} (this objkv reads format {VERSION} only; an older \
+                 bucket must be migrated, not opened)",
+                buf[4]
+            )));
+        }
+
+        let body = &buf[..buf.len() - 4];
+        let want = get_u32(buf, buf.len() - 4);
+        let got = crc32c::pg_comp_crc32c(0xffff_ffff, body) ^ 0xffff_ffff;
+        if want != got {
+            return Err(bad("checksum mismatch"));
+        }
+
+        let seq = get_u64(buf, 8);
+        let base_run_id = get_u64(buf, 16);
+        let count = get_u32(buf, 24) as usize;
+        let payload_len = get_u32(buf, 28) as usize;
+        let xid = get_u32(buf, 32);
+        let epoch = get_u64(buf, 36);
+        // The payload must reach the checksum and stop there. Fitting inside
+        // the object is not enough: a shorter length that lands on an entry
+        // boundary parses cleanly and silently drops every write after it.
+        if HEADER_LEN.checked_add(payload_len) != Some(buf.len() - 4) {
+            return Err(bad("payload does not end at the checksum"));
+        }
+        let payload =
+            take(buf, HEADER_LEN, payload_len).ok_or_else(|| bad("payload runs past the object"))?;
+
+        let mut entries = Vec::new();
+        let mut p = 0usize;
+        while p < payload.len() {
+            let klen = get_u32_checked(payload, p).ok_or_else(|| bad("truncated key length"))? as usize;
+            p += 4;
+            let key = take(payload, p, klen).ok_or_else(|| bad("key runs past the payload"))?.to_vec();
+            p += klen;
+            let tag = *payload.get(p).ok_or_else(|| bad("truncated entry tag"))?;
+            p += 1;
+            let vlen = get_u32_checked(payload, p).ok_or_else(|| bad("truncated value length"))? as usize;
+            p += 4;
+            let op = match tag {
+                0 => Op::Put(
+                    take(payload, p, vlen)
+                        .ok_or_else(|| bad("value runs past the payload"))?
+                        .to_vec(),
+                ),
+                1 => {
+                    // A tombstone carries no value; a length here would be
+                    // bytes the decoder skipped without reading.
+                    if vlen != 0 {
+                        return Err(bad("a delete entry with a value length"));
+                    }
+                    Op::Delete
+                }
+                t => return Err(bad(&format!("unknown entry tag {t}"))),
+            };
+            p += vlen;
+            if entries.len() == count {
+                return Err(bad("more entries than the header declares"));
+            }
+            entries.push(Entry { key, op });
+        }
+        if entries.len() != count {
+            return Err(bad("fewer entries than the header declares"));
+        }
+        // Sorted, unique keys are a precondition of `lookup` and `prefixed`,
+        // and they come from the BTreeMap the entries were built from.
+        if entries.windows(2).any(|w| w[0].key >= w[1].key) {
+            return Err(bad("entries are not in sorted key order"));
+        }
+        Ok(Commit { seq, base_run_id, xid, epoch, entries })
+    }
+
+    /// The CRC32C an encoded copy of this commit ends in: a fingerprint a
+    /// discard marker can carry, so the marker is matched to the object it
+    /// judges rather than to whatever later lands under the same number.
+    pub fn fingerprint(encoded: &[u8]) -> u32 {
+        get_u32_checked(encoded, encoded.len().saturating_sub(4)).unwrap_or(0)
+    }
+
+    /// Latest write for `key` in this commit, or `None` if untouched.
+    /// Entries are sorted by key -- they come out of a `BTreeMap` and are
+    /// encoded in that order -- so a lookup is a binary search rather than a
+    /// walk. A commit can hold hundreds of thousands of entries after a bulk
+    /// load, and this runs once per row read.
+    pub fn lookup(&self, key: &[u8]) -> Option<&Op> {
+        self.entries
+            .binary_search_by(|e| e.key.as_slice().cmp(key))
+            .ok()
+            .map(|i| &self.entries[i].op)
+    }
+
+    /// The entries in `[lo, hi)`. Sorted, so both ends are a binary search.
+    pub fn ranged(&self, lo: &[u8], hi: &[u8]) -> &[Entry] {
+        let start = self.entries.partition_point(|e| e.key.as_slice() < lo);
+        let end = self.entries.partition_point(|e| e.key.as_slice() < hi);
+        &self.entries[start..end.max(start)]
+    }
+
+    /// Every entry whose key starts with `prefix`, in key order.
+    pub fn prefixed(&self, prefix: &[u8]) -> &[Entry] {
+        let start = self
+            .entries
+            .partition_point(|e| e.key.as_slice() < prefix);
+        let len = self.entries[start..]
+            .iter()
+            .take_while(|e| e.key.starts_with(prefix))
+            .count();
+        &self.entries[start..start + len]
+    }
+}
+
+/// One object carrying every commit in `commits`, under the first one's key.
+///
+/// Each member keeps its own sequence number and header, so what the reader
+/// applies is a run of ordinary commits; only the PUT is shared. The members'
+/// numbers need not be contiguous: one can be dropped between staging and the
+/// write, and a gap in the numbering is not an error anywhere.
+pub fn encode_batch(commits: &[Commit]) -> Vec<u8> {
+    debug_assert!(commits.windows(2).all(|w| w[0].seq < w[1].seq));
+    let encoded: Vec<Vec<u8>> = commits.iter().map(Commit::encode).collect();
+    let members: Vec<&[u8]> = encoded.iter().map(Vec::as_slice).collect();
+    encode_batch_members(&members)
+}
+
+/// The same from members already encoded: the writer encodes each commit
+/// once, at staging, and the fingerprint a discard marker carries is of
+/// those exact bytes.
+pub fn encode_batch_members(members: &[&[u8]]) -> Vec<u8> {
+    debug_assert!(!members.is_empty());
+    let mut out = Vec::new();
+    put_u32(&mut out, BATCH_MAGIC);
+    out.push(BATCH_VERSION);
+    out.extend_from_slice(&[0, 0, 0]);
+    put_u32(&mut out, members.len() as u32);
+    debug_assert_eq!(out.len(), BATCH_HEADER_LEN);
+    for bytes in members {
+        put_u32(&mut out, bytes.len() as u32);
+        out.extend_from_slice(bytes);
+    }
+    let crc = crc32c::pg_comp_crc32c(0xffff_ffff, &out) ^ 0xffff_ffff;
+    put_u32(&mut out, crc);
+    out
+}
+
+/// The commits in one object, whichever form it takes. In ascending sequence
+/// order, which a batch is required to keep.
+pub fn decode_object(buf: &[u8]) -> io::Result<Vec<Commit>> {
+    Ok(decode_members(buf)?.into_iter().map(|(c, _)| c).collect())
+}
+
+/// `decode_object`, with each member's fingerprint (see
+/// [`Commit::fingerprint`]) so the open can match discard markers to them.
+pub fn decode_members(buf: &[u8]) -> io::Result<Vec<(Commit, u32)>> {
+    fn bad(what: &str) -> io::Error {
+        io::Error::other(format!("malformed batch object: {what}"))
+    }
+    if buf.len() < 4 {
+        return Err(bad("shorter than a magic number"));
+    }
+    if get_u32(buf, 0) != BATCH_MAGIC {
+        return Ok(vec![(Commit::decode(buf)?, Commit::fingerprint(buf))]);
+    }
+    if buf.len() < BATCH_HEADER_LEN + 4 {
+        return Err(bad("shorter than a header"));
+    }
+    if buf[4] != BATCH_VERSION {
+        return Err(bad(&format!("unsupported version {}", buf[4])));
+    }
+    let body = &buf[..buf.len() - 4];
+    let want = get_u32(buf, buf.len() - 4);
+    let got = crc32c::pg_comp_crc32c(0xffff_ffff, body) ^ 0xffff_ffff;
+    if want != got {
+        return Err(bad("checksum mismatch"));
+    }
+    let count = get_u32(buf, 8) as usize;
+    let mut out = Vec::with_capacity(count.min(1024));
+    let mut p = BATCH_HEADER_LEN;
+    while p < body.len() {
+        let len = get_u32_checked(body, p).ok_or_else(|| bad("truncated member length"))? as usize;
+        p += 4;
+        let member = body
+            .get(p..p.checked_add(len).ok_or_else(|| bad("member length overflows"))?)
+            .ok_or_else(|| bad("member runs past the object"))?;
+        p += len;
+        if out.len() == count {
+            return Err(bad("more members than the header declares"));
+        }
+        out.push((Commit::decode(member)?, Commit::fingerprint(member)));
+    }
+    if out.len() != count {
+        return Err(bad("fewer members than the header declares"));
+    }
+    if out.windows(2).any(|w| w[0].0.seq >= w[1].0.seq) {
+        return Err(bad("members are not in sequence order"));
+    }
+    Ok(out)
+}
+
+/// `get_u32` that returns `None` instead of panicking past the end.
+pub(crate) fn get_u32_checked(b: &[u8], at: usize) -> Option<u32> {
+    Some(u32::from_le_bytes(b.get(at..at + 4)?.try_into().ok()?))
+}
+
+pub(crate) fn put_u32(v: &mut Vec<u8>, x: u32) {
+    v.extend_from_slice(&x.to_le_bytes());
+}
+pub(crate) fn put_u64(v: &mut Vec<u8>, x: u64) {
+    v.extend_from_slice(&x.to_le_bytes());
+}
+pub(crate) fn get_u32(b: &[u8], at: usize) -> u32 {
+    u32::from_le_bytes(b[at..at + 4].try_into().unwrap())
+}
+pub(crate) fn get_u64(b: &[u8], at: usize) -> u64 {
+    u64::from_le_bytes(b[at..at + 8].try_into().unwrap())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample() -> Commit {
+        Commit {
+            seq: 123,
+            base_run_id: 5,
+            xid: 4242,
+            epoch: 6,
+            // Sorted and unique, as a commit built from a BTreeMap always is.
+            entries: vec![
+                Entry { key: b"alpha".to_vec(), op: Op::Put(b"one".to_vec()) },
+                Entry { key: b"alpha/child".to_vec(), op: Op::Put(b"two".to_vec()) },
+                Entry { key: b"beta".to_vec(), op: Op::Delete },
+            ],
+        }
+    }
+
+    #[test]
+    fn round_trips() {
+        let c = sample();
+        assert_eq!(Commit::decode(&c.encode()).unwrap(), c);
+    }
+
+    #[test]
+    fn empty_commit_round_trips() {
+        let c = Commit {
+            seq: 1,
+            base_run_id: 0,
+            xid: 1,
+            epoch: 0,
+            entries: vec![],
+        };
+        assert_eq!(Commit::decode(&c.encode()).unwrap(), c);
+    }
+
+    #[test]
+    fn lookup_finds_keys_and_misses_absent_ones() {
+        assert_eq!(sample().lookup(b"alpha"), Some(&Op::Put(b"one".to_vec())));
+        assert_eq!(sample().lookup(b"beta"), Some(&Op::Delete));
+        assert_eq!(sample().lookup(b"gamma"), None);
+        assert_eq!(sample().lookup(b"al"), None, "a prefix is not a key");
+    }
+
+    #[test]
+    fn prefixed_returns_the_matching_run() {
+        let c = sample();
+        let keys: Vec<&[u8]> = c.prefixed(b"alpha").iter().map(|e| e.key.as_slice()).collect();
+        assert_eq!(keys, vec![&b"alpha"[..], &b"alpha/child"[..]]);
+        assert_eq!(c.prefixed(b"beta").len(), 1);
+        assert!(c.prefixed(b"zzz").is_empty());
+        assert_eq!(c.prefixed(b"").len(), 3);
+    }
+
+    #[test]
+    fn out_of_order_entries_are_rejected() {
+        // Binary search would answer wrongly rather than loudly, so a commit
+        // object whose entries are not sorted is treated as corrupt.
+        let mut c = sample();
+        c.entries.swap(0, 2);
+        let bytes = c.encode();
+        let err = Commit::decode(&bytes).unwrap_err();
+        assert!(err.to_string().contains("sorted"), "{err}");
+    }
+
+    #[test]
+    fn detects_corruption() {
+        let mut bytes = sample().encode();
+        let n = bytes.len();
+        bytes[n / 2] ^= 0xff;
+        assert!(Commit::decode(&bytes).is_err());
+    }
+
+    #[test]
+    fn keys_sort_in_sequence_order() {
+        assert!(key_for(9) < key_for(10));
+        assert!(key_for(0xff) < key_for(0x100));
+    }
+
+    #[test]
+    fn a_batch_round_trips_and_a_plain_commit_reads_as_a_batch_of_one() {
+        let mut a = sample();
+        let mut b = sample();
+        b.seq = 125; // a gap is allowed: 124 was dropped before the write
+        b.entries.pop();
+        a.seq = 123;
+        let bytes = encode_batch(&[a.clone(), b.clone()]);
+        assert_eq!(decode_object(&bytes).unwrap(), vec![a.clone(), b]);
+        assert_eq!(decode_object(&a.encode()).unwrap(), vec![a]);
+    }
+
+    #[test]
+    fn a_batch_out_of_order_or_corrupted_is_refused() {
+        let mut a = sample();
+        let mut b = sample();
+        a.seq = 5;
+        b.seq = 4;
+        // Built by hand: encode_batch asserts the order in debug builds.
+        let mut out = Vec::new();
+        put_u32(&mut out, BATCH_MAGIC);
+        out.push(BATCH_VERSION);
+        out.extend_from_slice(&[0, 0, 0]);
+        put_u32(&mut out, 2);
+        for c in [&a, &b] {
+            let bytes = c.encode();
+            put_u32(&mut out, bytes.len() as u32);
+            out.extend_from_slice(&bytes);
+        }
+        let crc = crc32c::pg_comp_crc32c(0xffff_ffff, &out) ^ 0xffff_ffff;
+        put_u32(&mut out, crc);
+        assert!(decode_object(&out).unwrap_err().to_string().contains("sequence order"));
+
+        let good = encode_batch(&[b.clone(), a.clone()]);
+        let mut flipped = good.clone();
+        let n = flipped.len();
+        flipped[n / 2] ^= 0xff;
+        assert!(decode_object(&flipped).is_err());
+        for n in 0..good.len() {
+            let _ = decode_object(&good[..n]); // never panics
+        }
+    }
+
+    #[test]
+    fn a_fingerprint_names_the_bytes_and_nothing_else() {
+        let a = sample().encode();
+        let mut b = sample();
+        b.xid += 1;
+        let b = b.encode();
+        assert_eq!(Commit::fingerprint(&a), Commit::fingerprint(&sample().encode()));
+        assert_ne!(Commit::fingerprint(&a), Commit::fingerprint(&b));
+        let members = decode_members(&encode_batch(&[sample()])).unwrap();
+        assert_eq!(members[0].1, Commit::fingerprint(&a), "a batch member keeps its own fingerprint");
+    }
+
+    #[test]
+    fn an_older_format_is_refused_by_name() {
+        let mut b = sample().encode();
+        b[4] = 1;
+        let n = b.len();
+        let crc = crc32c::pg_comp_crc32c(0xffff_ffff, &b[..n - 4]) ^ 0xffff_ffff;
+        b[n - 4..].copy_from_slice(&crc.to_le_bytes());
+        let err = Commit::decode(&b).unwrap_err().to_string();
+        assert!(err.contains("unsupported version 1"), "{err}");
+    }
+
+    #[test]
+    fn a_delete_with_a_value_length_is_corrupt() {
+        let c = Commit { entries: vec![Entry { key: b"k".to_vec(), op: Op::Delete }], ..sample() };
+        let mut b = c.encode();
+        // The delete's vlen field sits right after its tag byte.
+        let at = HEADER_LEN + 4 + 1 + 1;
+        assert_eq!(b[at - 1], 1, "the tag byte before it says delete");
+        b[at..at + 4].copy_from_slice(&3u32.to_le_bytes());
+        let n = b.len();
+        let crc = crc32c::pg_comp_crc32c(0xffff_ffff, &b[..n - 4]) ^ 0xffff_ffff;
+        b[n - 4..].copy_from_slice(&crc.to_le_bytes());
+        let err = Commit::decode(&b).unwrap_err().to_string();
+        assert!(err.contains("delete entry"), "{err}");
+    }
+
+    #[test]
+    fn decode_never_panics_on_malformed_input() {
+        let good = sample().encode();
+
+        // Truncation at every length, including mid-header and mid-entry.
+        for n in 0..good.len() {
+            let _ = Commit::decode(&good[..n]);
+        }
+
+        // Length fields that lie. Each is re-checksummed so the CRC does not
+        // reject it first -- the point is that the *parser* holds, not that
+        // the checksum happens to catch it.
+        let relie = |off: usize, val: u32| {
+            let mut b = good.clone();
+            b[off..off + 4].copy_from_slice(&val.to_le_bytes());
+            let n = b.len();
+            let crc = crc32c::pg_comp_crc32c(0xffff_ffff, &b[..n - 4]) ^ 0xffff_ffff;
+            b[n - 4..].copy_from_slice(&crc.to_le_bytes());
+            b
+        };
+        for (off, val) in [
+            (24, u32::MAX),  // entry count
+            (28, u32::MAX),  // payload length
+            (28, 0),
+            (24, 0),
+        ] {
+            let err = Commit::decode(&relie(off, val)).unwrap_err().to_string();
+            assert!(err.contains("malformed commit object"), "got: {err}");
+        }
+
+        // A key length that runs past the payload.
+        let mut b = good.clone();
+        b[HEADER_LEN..HEADER_LEN + 4].copy_from_slice(&u32::MAX.to_le_bytes());
+        let n = b.len();
+        let crc = crc32c::pg_comp_crc32c(0xffff_ffff, &b[..n - 4]) ^ 0xffff_ffff;
+        b[n - 4..].copy_from_slice(&crc.to_le_bytes());
+        assert!(Commit::decode(&b).is_err());
+
+        // Random noise of every plausible length.
+        for len in [0usize, 1, 8, HEADER_LEN, HEADER_LEN + 4, 100] {
+            let noise: Vec<u8> = (0..len).map(|i| (i * 37 + 11) as u8).collect();
+            let _ = Commit::decode(&noise);
+        }
+    }
+
+}

--- a/crates/_support/objkv/src/commit.rs
+++ b/crates/_support/objkv/src/commit.rs
@@ -87,7 +87,7 @@ impl Commit {
         put_u64(&mut out, self.epoch);
         debug_assert_eq!(out.len(), HEADER_LEN);
         out.extend_from_slice(&payload);
-        let crc = crc32c::pg_comp_crc32c(0xffff_ffff, &out) ^ 0xffff_ffff;
+        let crc = crate::crc(&out);
         put_u32(&mut out, crc);
         out
     }
@@ -145,7 +145,7 @@ impl Commit {
 
         let body = &buf[..buf.len() - 4];
         let want = get_u32(buf, buf.len() - 4);
-        let got = crc32c::pg_comp_crc32c(0xffff_ffff, body) ^ 0xffff_ffff;
+        let got = crate::crc(body);
         if want != got {
             return Err(bad("checksum mismatch"));
         }
@@ -276,7 +276,7 @@ pub fn encode_batch_members(members: &[&[u8]]) -> Vec<u8> {
         put_u32(&mut out, bytes.len() as u32);
         out.extend_from_slice(bytes);
     }
-    let crc = crc32c::pg_comp_crc32c(0xffff_ffff, &out) ^ 0xffff_ffff;
+    let crc = crate::crc(&out);
     put_u32(&mut out, crc);
     out
 }
@@ -307,7 +307,7 @@ pub fn decode_members(buf: &[u8]) -> io::Result<Vec<(Commit, u32)>> {
     }
     let body = &buf[..buf.len() - 4];
     let want = get_u32(buf, buf.len() - 4);
-    let got = crc32c::pg_comp_crc32c(0xffff_ffff, body) ^ 0xffff_ffff;
+    let got = crate::crc(body);
     if want != got {
         return Err(bad("checksum mismatch"));
     }
@@ -462,7 +462,7 @@ mod tests {
             put_u32(&mut out, bytes.len() as u32);
             out.extend_from_slice(&bytes);
         }
-        let crc = crc32c::pg_comp_crc32c(0xffff_ffff, &out) ^ 0xffff_ffff;
+        let crc = crate::crc(&out);
         put_u32(&mut out, crc);
         assert!(decode_object(&out).unwrap_err().to_string().contains("sequence order"));
 
@@ -493,7 +493,7 @@ mod tests {
         let mut b = sample().encode();
         b[4] = 1;
         let n = b.len();
-        let crc = crc32c::pg_comp_crc32c(0xffff_ffff, &b[..n - 4]) ^ 0xffff_ffff;
+        let crc = crate::crc(&b[..n - 4]);
         b[n - 4..].copy_from_slice(&crc.to_le_bytes());
         let err = Commit::decode(&b).unwrap_err().to_string();
         assert!(err.contains("unsupported version 1"), "{err}");
@@ -508,7 +508,7 @@ mod tests {
         assert_eq!(b[at - 1], 1, "the tag byte before it says delete");
         b[at..at + 4].copy_from_slice(&3u32.to_le_bytes());
         let n = b.len();
-        let crc = crc32c::pg_comp_crc32c(0xffff_ffff, &b[..n - 4]) ^ 0xffff_ffff;
+        let crc = crate::crc(&b[..n - 4]);
         b[n - 4..].copy_from_slice(&crc.to_le_bytes());
         let err = Commit::decode(&b).unwrap_err().to_string();
         assert!(err.contains("delete entry"), "{err}");
@@ -530,7 +530,7 @@ mod tests {
             let mut b = good.clone();
             b[off..off + 4].copy_from_slice(&val.to_le_bytes());
             let n = b.len();
-            let crc = crc32c::pg_comp_crc32c(0xffff_ffff, &b[..n - 4]) ^ 0xffff_ffff;
+            let crc = crate::crc(&b[..n - 4]);
             b[n - 4..].copy_from_slice(&crc.to_le_bytes());
             b
         };
@@ -548,7 +548,7 @@ mod tests {
         let mut b = good.clone();
         b[HEADER_LEN..HEADER_LEN + 4].copy_from_slice(&u32::MAX.to_le_bytes());
         let n = b.len();
-        let crc = crc32c::pg_comp_crc32c(0xffff_ffff, &b[..n - 4]) ^ 0xffff_ffff;
+        let crc = crate::crc(&b[..n - 4]);
         b[n - 4..].copy_from_slice(&crc.to_le_bytes());
         assert!(Commit::decode(&b).is_err());
 

--- a/crates/_support/objkv/src/faults.rs
+++ b/crates/_support/objkv/src/faults.rs
@@ -1,0 +1,651 @@
+//! A fault-injecting [`Store`] wrapper for tests.
+//!
+//! Every fault this store can inject is something a real object store or the
+//! network between us and it does: a PUT that lands but whose 200 never
+//! comes back, a PUT that never leaves the building, a body that arrives
+//! torn, a listing that has not caught up, a ranged GET that comes back
+//! short. The engine's correctness argument is about what it does when the
+//! store misbehaves in exactly these ways, and this is how a test says
+//! "misbehave here, now".
+//!
+//! Deterministic: every random choice comes from an xorshift generator
+//! seeded by the caller, so a failing seed replays. Faults come from two
+//! sources, scripted [`Rule`]s (checked first) and a per-operation
+//! probability. Every operation, with the fault injected into it if any,
+//! goes into a log a test prints on failure.
+//!
+//! Delays are a hook, not a `thread::sleep`, because a sleep in production
+//! code is what the determinism lint fences off; a threaded test installs
+//! the sleeper it wants with [`FaultStore::set_sleeper`].
+
+use std::collections::BTreeSet;
+use std::fmt;
+use std::io;
+use std::sync::Arc;
+
+use pgsync::Mutex;
+
+use crate::s3::{ObjectInfo, PutOutcome};
+use crate::store::Store;
+
+/// Which store method an operation is.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum OpKind {
+    Put,
+    Get,
+    GetRange,
+    List,
+    Delete,
+}
+
+impl fmt::Display for OpKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            OpKind::Put => "put_if_absent",
+            OpKind::Get => "get",
+            OpKind::GetRange => "get_range",
+            OpKind::List => "list",
+            OpKind::Delete => "delete",
+        })
+    }
+}
+
+/// What can go wrong with one operation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Fault {
+    /// The write is performed, then an error is returned: the response was
+    /// lost. Applies to `put_if_absent` and `delete`.
+    ErrAfterLanded,
+    /// An error is returned and nothing is written. Applies to
+    /// `put_if_absent` and `delete`.
+    ErrBeforeLanded,
+    /// The operation is delayed by this many milliseconds through the
+    /// installed sleeper (a no-op by default), then performed normally.
+    Delay(u64),
+    /// The object is written truncated at a random point, or with a few
+    /// bytes flipped, and `Ok(Written)` is returned. Applies to
+    /// `put_if_absent`.
+    TornObject,
+    /// `put_if_absent` reports `AlreadyExists` without writing anything.
+    PhantomExists,
+    /// `list` omits the newest (lexicographically last) `n` objects.
+    ListStale(u32),
+    /// `get`, `get_range` or `list` fails with an error.
+    GetErr,
+    /// `get_range` returns fewer bytes than were asked for.
+    GetRangeShort,
+}
+
+impl Fault {
+    /// Whether this fault makes sense for the given operation.
+    pub fn applies_to(self, op: OpKind) -> bool {
+        match self {
+            Fault::ErrAfterLanded | Fault::ErrBeforeLanded => matches!(op, OpKind::Put | OpKind::Delete),
+            Fault::Delay(_) => true,
+            Fault::TornObject | Fault::PhantomExists => op == OpKind::Put,
+            Fault::ListStale(_) => op == OpKind::List,
+            Fault::GetErr => matches!(op, OpKind::Get | OpKind::GetRange | OpKind::List),
+            Fault::GetRangeShort => op == OpKind::GetRange,
+        }
+    }
+
+    /// Every kind, with the parameters random faults use.
+    pub fn all() -> Vec<Fault> {
+        vec![
+            Fault::ErrAfterLanded,
+            Fault::ErrBeforeLanded,
+            Fault::Delay(5),
+            Fault::TornObject,
+            Fault::PhantomExists,
+            Fault::ListStale(1),
+            Fault::GetErr,
+            Fault::GetRangeShort,
+        ]
+    }
+}
+
+impl fmt::Display for Fault {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Fault::Delay(ms) => write!(f, "Delay({ms}ms)"),
+            Fault::ListStale(n) => write!(f, "ListStale({n})"),
+            other => write!(f, "{other:?}"),
+        }
+    }
+}
+
+/// A scripted fault: the `nth` operation of kind `op` on a key under
+/// `prefix` gets `fault`. With `nth` of `None` every matching operation
+/// does, up to `times` of them.
+#[derive(Debug, Clone)]
+pub struct Rule {
+    pub op: OpKind,
+    pub prefix: String,
+    pub nth: Option<u64>,
+    pub fault: Fault,
+    pub times: Option<u32>,
+    seen: u64,
+    fired: u32,
+}
+
+impl Rule {
+    /// The `nth` (1-based) matching operation gets the fault, once.
+    pub fn nth(op: OpKind, prefix: &str, nth: u64, fault: Fault) -> Rule {
+        Rule { op, prefix: prefix.to_string(), nth: Some(nth), fault, times: Some(1), seen: 0, fired: 0 }
+    }
+
+    /// Every matching operation gets the fault.
+    pub fn every(op: OpKind, prefix: &str, fault: Fault) -> Rule {
+        Rule { op, prefix: prefix.to_string(), nth: None, fault, times: None, seen: 0, fired: 0 }
+    }
+
+    /// Every matching operation gets the fault, the first `times` of them.
+    pub fn first(op: OpKind, prefix: &str, times: u32, fault: Fault) -> Rule {
+        Rule { op, prefix: prefix.to_string(), nth: None, fault, times: Some(times), seen: 0, fired: 0 }
+    }
+
+    fn matches(&mut self, op: OpKind, key: &str) -> Option<Fault> {
+        if op != self.op || !key.starts_with(&self.prefix) || !self.fault.applies_to(op) {
+            return None;
+        }
+        if self.times.is_some_and(|t| self.fired >= t) {
+            return None;
+        }
+        self.seen += 1;
+        let hit = match self.nth {
+            Some(n) => self.seen == n,
+            None => true,
+        };
+        if hit {
+            self.fired += 1;
+            Some(self.fault)
+        } else {
+            None
+        }
+    }
+}
+
+/// One store operation as the log records it.
+#[derive(Debug, Clone)]
+pub struct Event {
+    /// Position in the log, from 1.
+    pub n: u64,
+    pub op: OpKind,
+    pub key: String,
+    /// Bytes written, or the range asked for, or nothing.
+    pub detail: String,
+    pub fault: Option<Fault>,
+    /// What the caller was told.
+    pub result: String,
+}
+
+impl fmt::Display for Event {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "#{:<5} {} {}", self.n, self.op, self.key)?;
+        if !self.detail.is_empty() {
+            write!(f, " {}", self.detail)?;
+        }
+        if let Some(fault) = self.fault {
+            write!(f, "  <<{fault}>>")?;
+        }
+        write!(f, "  -> {}", self.result)
+    }
+}
+
+/// xorshift64*: small, seedable, good enough to pick faults with.
+#[derive(Debug, Clone)]
+pub struct XorShift(u64);
+
+impl XorShift {
+    pub fn new(seed: u64) -> XorShift {
+        // Zero is a fixed point; mix the seed so that seed 0 works too.
+        XorShift(seed.wrapping_mul(0x9E37_79B9_7F4A_7C15) ^ 0xD1B5_4A32_D192_ED03 | 1)
+    }
+    pub fn next_u64(&mut self) -> u64 {
+        let mut x = self.0;
+        x ^= x >> 12;
+        x ^= x << 25;
+        x ^= x >> 27;
+        self.0 = x;
+        x.wrapping_mul(0x2545_F491_4F6C_DD1D)
+    }
+    /// Uniform in `[0, 1)`.
+    pub fn next_f64(&mut self) -> f64 {
+        (self.next_u64() >> 11) as f64 / (1u64 << 53) as f64
+    }
+    /// Uniform in `[0, n)`; `0` when `n` is `0`.
+    pub fn below(&mut self, n: u64) -> u64 {
+        if n == 0 {
+            0
+        } else {
+            self.next_u64() % n
+        }
+    }
+    pub fn chance(&mut self, p: f64) -> bool {
+        self.next_f64() < p
+    }
+}
+
+struct State {
+    rng: XorShift,
+    rules: Vec<Rule>,
+    /// Probability that an operation with no scripted fault gets a random
+    /// one, and which kinds it may be.
+    rate: f64,
+    kinds: Vec<Fault>,
+    enabled: bool,
+    log: Vec<Event>,
+    /// Keys whose bodies were written torn, so a test knows a later
+    /// decode failure is the store's doing.
+    torn: BTreeSet<String>,
+    faults_injected: u64,
+}
+
+type Sleeper = Box<dyn Fn(u64) + Send + Sync>;
+
+/// A [`Store`] that injects faults into another. See the module doc.
+pub struct FaultStore {
+    inner: Arc<dyn Store>,
+    state: Mutex<State>,
+    sleeper: Mutex<Option<Sleeper>>,
+}
+
+impl FaultStore {
+    /// Wraps `inner`; no faults until rules or a rate are set.
+    pub fn new(inner: Arc<dyn Store>, seed: u64) -> FaultStore {
+        FaultStore {
+            inner,
+            state: Mutex::new(State {
+                rng: XorShift::new(seed),
+                rules: Vec::new(),
+                rate: 0.0,
+                kinds: Fault::all(),
+                enabled: true,
+                log: Vec::new(),
+                torn: BTreeSet::new(),
+                faults_injected: 0,
+            }),
+            sleeper: Mutex::new(None),
+        }
+    }
+
+    /// The store underneath, for a test that wants to look at the bucket
+    /// without going through the faults.
+    pub fn inner(&self) -> &Arc<dyn Store> {
+        &self.inner
+    }
+
+    pub fn add_rule(&self, rule: Rule) {
+        self.state.lock().unwrap().rules.push(rule);
+    }
+
+    pub fn clear_rules(&self) {
+        self.state.lock().unwrap().rules.clear();
+    }
+
+    /// Probability, per operation, of a random fault of one of `kinds`
+    /// (those that apply to the operation). `kinds` empty means all.
+    pub fn set_random(&self, rate: f64, kinds: &[Fault]) {
+        let mut s = self.state.lock().unwrap();
+        s.rate = rate;
+        s.kinds = if kinds.is_empty() { Fault::all() } else { kinds.to_vec() };
+    }
+
+    /// Turns injection off (or on) without forgetting the rules: how a test
+    /// verifies against the bucket as it truly is.
+    pub fn set_enabled(&self, on: bool) {
+        self.state.lock().unwrap().enabled = on;
+    }
+
+    /// What `Fault::Delay` calls. A threaded test installs a real sleep.
+    pub fn set_sleeper(&self, f: impl Fn(u64) + Send + Sync + 'static) {
+        *self.sleeper.lock().unwrap() = Some(Box::new(f));
+    }
+
+    pub fn events(&self) -> Vec<Event> {
+        self.state.lock().unwrap().log.clone()
+    }
+
+    pub fn clear_log(&self) {
+        self.state.lock().unwrap().log.clear();
+    }
+
+    /// The whole log, one operation per line.
+    pub fn log(&self) -> String {
+        let s = self.state.lock().unwrap();
+        let mut out = String::new();
+        for e in &s.log {
+            out.push_str(&e.to_string());
+            out.push('\n');
+        }
+        out
+    }
+
+    /// The last `n` lines of the log: what a failure message wants.
+    pub fn tail(&self, n: usize) -> String {
+        let s = self.state.lock().unwrap();
+        let skip = s.log.len().saturating_sub(n);
+        let mut out = String::new();
+        if skip > 0 {
+            out.push_str(&format!("... {skip} earlier operation(s) omitted ...\n"));
+        }
+        for e in &s.log[skip..] {
+            out.push_str(&e.to_string());
+            out.push('\n');
+        }
+        out
+    }
+
+    /// Only the operations that had a fault injected.
+    pub fn faults(&self) -> Vec<Event> {
+        self.state.lock().unwrap().log.iter().filter(|e| e.fault.is_some()).cloned().collect()
+    }
+
+    pub fn faults_injected(&self) -> u64 {
+        self.state.lock().unwrap().faults_injected
+    }
+
+    /// Keys written torn so far.
+    pub fn torn_keys(&self) -> Vec<String> {
+        self.state.lock().unwrap().torn.iter().cloned().collect()
+    }
+
+    /// Tears `body` with the generator: truncates it or flips bytes.
+    pub fn tear(rng: &mut XorShift, body: &[u8]) -> Vec<u8> {
+        if body.is_empty() {
+            return Vec::new();
+        }
+        if rng.chance(0.5) {
+            let at = rng.below(body.len() as u64) as usize;
+            body[..at].to_vec()
+        } else {
+            let mut b = body.to_vec();
+            let flips = 1 + rng.below(3) as usize;
+            for _ in 0..flips {
+                let i = rng.below(b.len() as u64) as usize;
+                let bit = 1u8 << rng.below(8);
+                b[i] ^= bit;
+            }
+            b
+        }
+    }
+
+    /// Decides the fault for one operation, if any, and reserves its log
+    /// slot. The slot is filled by `record`.
+    fn plan(&self, op: OpKind, key: &str, detail: String) -> (u64, Option<Fault>) {
+        let mut s = self.state.lock().unwrap();
+        let n = s.log.len() as u64 + 1;
+        s.log.push(Event { n, op, key: key.to_string(), detail, fault: None, result: String::new() });
+        if !s.enabled {
+            return (n, None);
+        }
+        let mut fault = s.rules.iter_mut().find_map(|r| r.matches(op, key));
+        let rate = s.rate;
+        if fault.is_none() && rate > 0.0 && s.rng.chance(rate) {
+            let applicable: Vec<Fault> = s.kinds.iter().copied().filter(|f| f.applies_to(op)).collect();
+            if !applicable.is_empty() {
+                let i = s.rng.below(applicable.len() as u64) as usize;
+                fault = Some(applicable[i]);
+            }
+        }
+        if fault.is_some() {
+            s.faults_injected += 1;
+        }
+        let idx = (n - 1) as usize;
+        s.log[idx].fault = fault;
+        (n, fault)
+    }
+
+    fn record(&self, n: u64, result: String) {
+        let mut s = self.state.lock().unwrap();
+        let idx = (n - 1) as usize;
+        if let Some(e) = s.log.get_mut(idx) {
+            e.result = result;
+        }
+    }
+
+    fn injected(&self, n: u64, fault: Fault, op: OpKind, key: &str) -> io::Error {
+        io::Error::other(format!("injected fault #{n}: {fault} on {op} {key}"))
+    }
+
+    fn delay(&self, ms: u64) {
+        if let Some(f) = self.sleeper.lock().unwrap().as_ref() {
+            f(ms.min(1_000));
+        }
+    }
+
+    fn rng<T>(&self, f: impl FnOnce(&mut XorShift) -> T) -> T {
+        f(&mut self.state.lock().unwrap().rng)
+    }
+}
+
+fn show_put(r: &io::Result<PutOutcome>) -> String {
+    match r {
+        Ok(PutOutcome::Written) => "Written".into(),
+        Ok(PutOutcome::AlreadyExists) => "AlreadyExists".into(),
+        Err(e) => format!("Err({e})"),
+    }
+}
+
+fn show_bytes(r: &io::Result<Option<Vec<u8>>>) -> String {
+    match r {
+        Ok(Some(b)) => format!("Some({} bytes)", b.len()),
+        Ok(None) => "None".into(),
+        Err(e) => format!("Err({e})"),
+    }
+}
+
+impl Store for FaultStore {
+    fn put_if_absent(&self, key: &str, body: &[u8]) -> io::Result<PutOutcome> {
+        let (n, fault) = self.plan(OpKind::Put, key, format!("({} bytes)", body.len()));
+        let r = match fault {
+            None => self.inner.put_if_absent(key, body),
+            Some(Fault::Delay(ms)) => {
+                self.delay(ms);
+                self.inner.put_if_absent(key, body)
+            }
+            Some(f @ Fault::ErrAfterLanded) => {
+                let _ = self.inner.put_if_absent(key, body);
+                Err(self.injected(n, f, OpKind::Put, key))
+            }
+            Some(f @ Fault::ErrBeforeLanded) => Err(self.injected(n, f, OpKind::Put, key)),
+            Some(Fault::TornObject) => {
+                let torn = self.rng(|rng| FaultStore::tear(rng, body));
+                let r = self.inner.put_if_absent(key, &torn);
+                if matches!(r, Ok(PutOutcome::Written)) {
+                    self.state.lock().unwrap().torn.insert(key.to_string());
+                }
+                r
+            }
+            Some(Fault::PhantomExists) => Ok(PutOutcome::AlreadyExists),
+            Some(f) => Err(self.injected(n, f, OpKind::Put, key)),
+        };
+        self.record(n, show_put(&r));
+        r
+    }
+
+    fn get(&self, key: &str) -> io::Result<Option<Vec<u8>>> {
+        let (n, fault) = self.plan(OpKind::Get, key, String::new());
+        let r = match fault {
+            None => self.inner.get(key),
+            Some(Fault::Delay(ms)) => {
+                self.delay(ms);
+                self.inner.get(key)
+            }
+            Some(f) => Err(self.injected(n, f, OpKind::Get, key)),
+        };
+        self.record(n, show_bytes(&r));
+        r
+    }
+
+    fn get_range(&self, key: &str, offset: u64, len: u64) -> io::Result<Option<Vec<u8>>> {
+        let (n, fault) = self.plan(OpKind::GetRange, key, format!("[{offset}..+{len}]"));
+        let r = match fault {
+            None => self.inner.get_range(key, offset, len),
+            Some(Fault::Delay(ms)) => {
+                self.delay(ms);
+                self.inner.get_range(key, offset, len)
+            }
+            Some(Fault::GetRangeShort) => match self.inner.get_range(key, offset, len) {
+                Ok(Some(b)) if !b.is_empty() => {
+                    let keep = self.rng(|rng| rng.below(b.len() as u64)) as usize;
+                    Ok(Some(b[..keep].to_vec()))
+                }
+                other => other,
+            },
+            Some(f) => Err(self.injected(n, f, OpKind::GetRange, key)),
+        };
+        self.record(n, show_bytes(&r));
+        r
+    }
+
+    fn list(&self, prefix: &str) -> io::Result<Vec<ObjectInfo>> {
+        let (n, fault) = self.plan(OpKind::List, prefix, String::new());
+        let r = match fault {
+            None => self.inner.list(prefix),
+            Some(Fault::Delay(ms)) => {
+                self.delay(ms);
+                self.inner.list(prefix)
+            }
+            Some(Fault::ListStale(k)) => self.inner.list(prefix).map(|mut v| {
+                v.sort_by(|a, b| a.key.cmp(&b.key));
+                let keep = v.len().saturating_sub(k as usize);
+                v.truncate(keep);
+                v
+            }),
+            Some(f) => Err(self.injected(n, f, OpKind::List, prefix)),
+        };
+        self.record(
+            n,
+            match &r {
+                Ok(v) => format!("{} object(s)", v.len()),
+                Err(e) => format!("Err({e})"),
+            },
+        );
+        r
+    }
+
+    fn delete(&self, key: &str) -> io::Result<()> {
+        let (n, fault) = self.plan(OpKind::Delete, key, String::new());
+        let r = match fault {
+            None => self.inner.delete(key),
+            Some(Fault::Delay(ms)) => {
+                self.delay(ms);
+                self.inner.delete(key)
+            }
+            Some(f @ Fault::ErrAfterLanded) => {
+                let _ = self.inner.delete(key);
+                Err(self.injected(n, f, OpKind::Delete, key))
+            }
+            Some(f) => Err(self.injected(n, f, OpKind::Delete, key)),
+        };
+        self.record(
+            n,
+            match &r {
+                Ok(()) => "Ok".into(),
+                Err(e) => format!("Err({e})"),
+            },
+        );
+        r
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::store::MemStore;
+
+    fn wrapped(seed: u64) -> (Arc<MemStore>, Arc<FaultStore>) {
+        let m = Arc::new(MemStore::new());
+        let f = Arc::new(FaultStore::new(Arc::clone(&m) as Arc<dyn Store>, seed));
+        (m, f)
+    }
+
+    #[test]
+    fn a_scripted_rule_hits_the_nth_matching_operation_only() {
+        let (m, f) = wrapped(1);
+        f.add_rule(Rule::nth(OpKind::Put, "commit/", 2, Fault::ErrAfterLanded));
+        assert_eq!(f.put_if_absent("commit/1", b"a").unwrap(), PutOutcome::Written);
+        assert_eq!(f.put_if_absent("other/1", b"x").unwrap(), PutOutcome::Written);
+        assert!(f.put_if_absent("commit/2", b"b").is_err(), "the second commit/ put");
+        assert_eq!(m.get("commit/2").unwrap(), Some(b"b".to_vec()), "but it landed");
+        assert_eq!(f.put_if_absent("commit/3", b"c").unwrap(), PutOutcome::Written, "once only");
+        assert_eq!(f.faults().len(), 1);
+        assert!(f.log().contains("<<ErrAfterLanded>>"), "{}", f.log());
+    }
+
+    #[test]
+    fn phantom_exists_and_err_before_landed_write_nothing() {
+        let (m, f) = wrapped(2);
+        f.add_rule(Rule::nth(OpKind::Put, "a", 1, Fault::PhantomExists));
+        f.add_rule(Rule::nth(OpKind::Put, "b", 1, Fault::ErrBeforeLanded));
+        assert_eq!(f.put_if_absent("a", b"1").unwrap(), PutOutcome::AlreadyExists);
+        assert!(f.put_if_absent("b", b"2").is_err());
+        assert!(m.list("").unwrap().is_empty());
+    }
+
+    #[test]
+    fn a_torn_object_differs_from_what_was_sent_and_is_remembered() {
+        for seed in 0..50 {
+            let (m, f) = wrapped(seed);
+            f.add_rule(Rule::every(OpKind::Put, "run/", Fault::TornObject));
+            let body: Vec<u8> = (0..200u32).map(|i| i as u8).collect();
+            assert_eq!(f.put_if_absent("run/1", &body).unwrap(), PutOutcome::Written);
+            let stored = m.get("run/1").unwrap().unwrap();
+            assert_ne!(stored, body, "seed {seed}");
+            assert_eq!(f.torn_keys(), vec!["run/1".to_string()]);
+        }
+    }
+
+    #[test]
+    fn a_stale_list_omits_the_newest_and_a_short_range_comes_back_short() {
+        let (_, f) = wrapped(3);
+        for k in ["x/1", "x/2", "x/3"] {
+            f.put_if_absent(k, b"0123456789").unwrap();
+        }
+        f.add_rule(Rule::nth(OpKind::List, "x/", 1, Fault::ListStale(1)));
+        let keys: Vec<String> = f.list("x/").unwrap().into_iter().map(|i| i.key).collect();
+        assert_eq!(keys, vec!["x/1", "x/2"]);
+        f.add_rule(Rule::every(OpKind::GetRange, "x/", Fault::GetRangeShort));
+        let b = f.get_range("x/1", 0, 10).unwrap().unwrap();
+        assert!(b.len() < 10, "{}", b.len());
+        f.add_rule(Rule::every(OpKind::Get, "x/", Fault::GetErr));
+        assert!(f.get("x/1").is_err());
+    }
+
+    #[test]
+    fn the_same_seed_gives_the_same_faults_and_disabling_gives_none() {
+        let run = |seed: u64| -> Vec<Option<Fault>> {
+            let (_, f) = wrapped(seed);
+            f.set_random(0.5, &[]);
+            for i in 0..40 {
+                let _ = f.put_if_absent(&format!("k/{i}"), b"v");
+                let _ = f.get(&format!("k/{i}"));
+                let _ = f.list("k/");
+            }
+            f.events().into_iter().map(|e| e.fault).collect()
+        };
+        assert_eq!(run(7), run(7));
+        assert_ne!(run(7), run(8));
+        assert!(run(7).iter().any(Option::is_some));
+
+        let (_, f) = wrapped(7);
+        f.set_random(1.0, &[]);
+        f.set_enabled(false);
+        for i in 0..10 {
+            f.put_if_absent(&format!("k/{i}"), b"v").unwrap();
+        }
+        assert_eq!(f.faults_injected(), 0);
+    }
+
+    #[test]
+    fn a_delay_goes_through_the_installed_sleeper() {
+        let (_, f) = wrapped(4);
+        let slept = Arc::new(Mutex::new(Vec::new()));
+        let s2 = Arc::clone(&slept);
+        f.set_sleeper(move |ms| s2.lock().unwrap().push(ms));
+        f.add_rule(Rule::every(OpKind::Get, "", Fault::Delay(7)));
+        f.get("anything").unwrap();
+        assert_eq!(*slept.lock().unwrap(), vec![7]);
+    }
+}

--- a/crates/_support/objkv/src/faults.rs
+++ b/crates/_support/objkv/src/faults.rs
@@ -144,23 +144,25 @@ impl Rule {
         Rule { op, prefix: prefix.to_string(), nth: None, fault, times: Some(times), seen: 0, fired: 0 }
     }
 
-    fn matches(&mut self, op: OpKind, key: &str) -> Option<Fault> {
+    /// Whether this operation is one the rule is about. Every rule counts
+    /// every such operation, whichever rule ends up firing, so `nth` is a
+    /// position in the real operation sequence.
+    fn counts(&mut self, op: OpKind, key: &str) -> bool {
         if op != self.op || !key.starts_with(&self.prefix) || !self.fault.applies_to(op) {
-            return None;
+            return false;
         }
+        self.seen += 1;
+        true
+    }
+
+    /// The fault this rule wants for the operation `counts` just admitted.
+    fn wants(&self) -> Option<Fault> {
         if self.times.is_some_and(|t| self.fired >= t) {
             return None;
         }
-        self.seen += 1;
-        let hit = match self.nth {
-            Some(n) => self.seen == n,
-            None => true,
-        };
-        if hit {
-            self.fired += 1;
-            Some(self.fault)
-        } else {
-            None
+        match self.nth {
+            Some(n) if self.seen != n => None,
+            _ => Some(self.fault),
         }
     }
 }
@@ -361,10 +363,17 @@ impl FaultStore {
         } else {
             let mut b = body.to_vec();
             let flips = 1 + rng.below(3) as usize;
-            for _ in 0..flips {
+            // Distinct (byte, bit) pairs: two flips of the same bit would
+            // restore it, and a "torn" object that is byte-identical to the
+            // original is a fault that was never injected.
+            let mut done: Vec<(usize, u8)> = Vec::new();
+            while done.len() < flips {
                 let i = rng.below(b.len() as u64) as usize;
-                let bit = 1u8 << rng.below(8);
-                b[i] ^= bit;
+                let bit = rng.below(8) as u8;
+                if !done.contains(&(i, bit)) {
+                    done.push((i, bit));
+                    b[i] ^= 1u8 << bit;
+                }
             }
             b
         }
@@ -379,7 +388,15 @@ impl FaultStore {
         if !s.enabled {
             return (n, None);
         }
-        let mut fault = s.rules.iter_mut().find_map(|r| r.matches(op, key));
+        let mut fault = None;
+        for r in s.rules.iter_mut() {
+            if r.counts(op, key) && fault.is_none() {
+                if let Some(f) = r.wants() {
+                    r.fired += 1;
+                    fault = Some(f);
+                }
+            }
+        }
         let rate = s.rate;
         if fault.is_none() && rate > 0.0 && s.rng.chance(rate) {
             let applicable: Vec<Fault> = s.kinds.iter().copied().filter(|f| f.applies_to(op)).collect();

--- a/crates/_support/objkv/src/index_key.rs
+++ b/crates/_support/objkv/src/index_key.rs
@@ -1,0 +1,963 @@
+//! Index key encoding: an on-bucket format, so changing it means rewriting
+//! every entry. One rule drives it -- the bytewise order of an encoded key
+//! must equal the logical order of the values, since a range scan is a prefix
+//! seek and a walk, and disagreement means wrong rows with no error.
+//!
+//! ```text
+//! non-unique  {db:08x}/i/{index:08x}/{hex tuple}/{rowid:016x}/{version}
+//! unique      {db:08x}/u/{index:08x}/{hex tuple}/{version}   -> rowid
+//! ```
+//!
+//! `db` leads because oids repeat across databases; shared catalogs take
+//! `00000000`. Left of the version suffix is an ordinary row key, so entries
+//! get snapshot reads and tombstones free.
+//!
+//! The tuple goes in as hex, which keeps bytewise order and holds three
+//! invariants the readers lean on: a key never contains 0x00 (the store
+//! resumes a scan by appending one), never contains 0xff (the table AM's
+//! upper bound is a prefix plus one), and has `/` only between fields (the
+//! splitters below count on it). It costs 2x the bytes. A key is never an S3
+//! object name -- keys live inside commit and run objects -- so no charset or
+//! length rule of S3's applies here.
+
+use std::io;
+
+/// Largest encoded tuple, before hexing. Btree's limit on an 8K page
+/// (`BTMaxItemSize`, 2704 bytes at version 4), so an index row that fits in
+/// Postgres fits here; the store frames keys with a 32-bit length and has no
+/// limit of its own. Over this, insert errors as btree does -- never
+/// truncate, since a truncated key is a wrong key.
+pub const MAX_ENCODED: usize = 2704;
+
+/// A column's tag byte says whether a value follows and how it is stored.
+/// The four sort together as the options ask: a nulls-first NULL under
+/// every value, a nulls-last NULL over every value, and a descending value
+/// with each of its bytes inverted so that byte order is reversed value order.
+const TAG_PRESENT: u8 = 0x01;
+const TAG_PRESENT_DESC: u8 = 0xfe;
+pub const TAG_NULL: u8 = 0xff;
+pub const TAG_NULL_FIRST: u8 = 0x00;
+
+/// How one column is ordered in the key. The default is what `ASC NULLS
+/// LAST` means; DESC inverts the value's bytes and NULLS FIRST moves the
+/// null tag below every value.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct ColOpt {
+    pub desc: bool,
+    pub nulls_first: bool,
+}
+
+#[cfg(test)]
+pub const ASC: ColOpt = ColOpt { desc: false, nulls_first: false };
+
+pub fn is_null_tag(tag: u8) -> bool {
+    tag == TAG_NULL || tag == TAG_NULL_FIRST
+}
+
+/// A column's body as the encoder wrote it before any inversion, so the
+/// decoders below read one shape.
+pub fn column_body(tag: u8, body: &[u8]) -> std::borrow::Cow<'_, [u8]> {
+    if tag == TAG_PRESENT_DESC {
+        std::borrow::Cow::Owned(body.iter().map(|b| !b).collect())
+    } else {
+        std::borrow::Cow::Borrowed(body)
+    }
+}
+
+/// One column's value. Types the encoding refuses never reach here.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum Col<'a> {
+    Null,
+    Bool(bool),
+    Int2(i16),
+    Int4(i32),
+    Int8(i64),
+    Oid(u32),
+    /// `"char"`: one byte, compared unsigned, so it is its own sort key. The
+    /// catalogs key on it -- relkind, provolatile and friends.
+    Char(u8),
+    /// `name`: fixed 64 bytes, C collation, compared as a string. The trailing
+    /// NUL padding is not part of the value, so it is trimmed.
+    Name(&'a [u8]),
+    /// `oidvector` / `int2vector`: shorter vectors first, then element by
+    /// element -- `btoidvectorcmp`'s order, which compares the lengths before
+    /// any element. pg_proc lookups key on these.
+    Vector(&'a [u64]),
+    Uuid(&'a [u8; 16]),
+    Text(&'a [u8]),
+    /// `char(n)`: stored blank-padded to `n`, but `bpcharcmp` compares with
+    /// the trailing blanks stripped, so `'a'` and `'a  '` are one value. The
+    /// padding is trimmed before encoding, on entries and on bounds alike --
+    /// a padded entry against an unpadded bound is a miss with no error.
+    Bpchar(&'a [u8]),
+    /// Both float widths, single precision widened -- exactly, and in order --
+    /// so a `float8` bound can be compared against a `float4` column without
+    /// rounding it first. Postgres sorts NaN above every number and treats the
+    /// two zeros as one value, so both are normalised before encoding.
+    Float8(f64),
+}
+
+impl Col<'_> {
+    pub fn is_null(&self) -> bool {
+        matches!(self, Col::Null)
+    }
+}
+
+/// Flipping the sign bit maps the signed range onto the unsigned one in order.
+fn int_bytes(v: i64, width: usize) -> impl Iterator<Item = u8> {
+    let flipped = (v as u64) ^ (1u64 << (width * 8 - 1));
+    flipped.to_be_bytes().into_iter().skip(8 - width)
+}
+
+/// IEEE bits reordered so byte order is value order: flip the sign bit on a
+/// positive number, invert every bit on a negative one. That puts -inf lowest
+/// and NaN -- sign clear, exponent full -- above +inf, which is where Postgres
+/// puts it.
+fn float_bytes(v: f64) -> [u8; 8] {
+    // Every NaN to one NaN and -0 to 0: Postgres compares each pair equal, and
+    // two keys for one value would break a unique index.
+    let v = if v.is_nan() { f64::NAN } else { v + 0.0 };
+    let bits = v.to_bits();
+    let top = 1u64 << 63;
+    if bits & top != 0 { !bits } else { bits ^ top }.to_be_bytes()
+}
+
+fn encode_col(col: &Col<'_>, opt: ColOpt, out: &mut Vec<u8>) {
+    if col.is_null() {
+        out.push(if opt.nulls_first { TAG_NULL_FIRST } else { TAG_NULL });
+        return;
+    }
+    out.push(if opt.desc { TAG_PRESENT_DESC } else { TAG_PRESENT });
+    let body = out.len();
+    encode_body(col, out);
+    if opt.desc {
+        for b in &mut out[body..] {
+            *b = !*b;
+        }
+    }
+}
+
+fn encode_body(col: &Col<'_>, out: &mut Vec<u8>) {
+    match *col {
+        Col::Null => unreachable!("handled above"),
+        Col::Bool(b) => out.push(b as u8),
+        Col::Int2(v) => out.extend(int_bytes(v as i64, 2)),
+        Col::Int4(v) => out.extend(int_bytes(v as i64, 4)),
+        Col::Int8(v) => out.extend(int_bytes(v, 8)),
+        Col::Oid(v) => out.extend_from_slice(&v.to_be_bytes()),
+        Col::Char(c) => out.push(c),
+        Col::Vector(v) => {
+            // The element count first, as btoidvectorcmp compares; fixed
+            // width, so the encoding is prefix-free without a terminator.
+            out.extend_from_slice(&(v.len() as u32).to_be_bytes());
+            for e in v {
+                out.extend_from_slice(&e.to_be_bytes());
+            }
+        }
+        Col::Name(n) => {
+            let end = n.iter().position(|&b| b == 0).unwrap_or(n.len());
+            encode_string(&n[..end], out);
+        }
+        Col::Uuid(u) => out.extend_from_slice(u),
+        Col::Text(s) => encode_string(s, out),
+        Col::Bpchar(s) => encode_string(trim_blanks(s), out),
+        Col::Float8(v) => out.extend_from_slice(&float_bytes(v)),
+    }
+}
+
+/// `bcTruelen`: trailing 0x20 bytes only. A multibyte character never ends in
+/// one, so the byte test is the character test in every server encoding.
+fn trim_blanks(s: &[u8]) -> &[u8] {
+    let end = s.iter().rposition(|&b| b != b' ').map_or(0, |i| i + 1);
+    &s[..end]
+}
+
+/// 0x00 escapes to 0x00 0xff and the string ends 0x00 0x00, so the
+/// terminator is always the lowest thing that can follow a 0x00.
+fn encode_string(s: &[u8], out: &mut Vec<u8>) {
+    for &b in s {
+        out.push(b);
+        if b == 0 {
+            out.push(0xff);
+        }
+    }
+    out.extend_from_slice(&[0x00, 0x00]);
+}
+
+// --- Reading a value back out of a key ---------------------------------------
+//
+// An index entry carries every key column, so a query that wants only indexed
+// columns never has to fetch the row. Each of these is the exact inverse of
+// the encoder above; the caller supplies the column's bytes without its tag.
+
+/// Undoes the sign flip. `bytes` is the column's width, big-endian.
+pub fn decode_int(bytes: &[u8]) -> i64 {
+    let width = bytes.len();
+    let mut raw = 0u64;
+    for &b in bytes {
+        raw = (raw << 8) | b as u64;
+    }
+    let flipped = raw ^ (1u64 << (width * 8 - 1));
+    // Sign-extend from the column's width.
+    let shift = 64 - width * 8;
+    ((flipped << shift) as i64) >> shift
+}
+
+pub fn decode_uint(bytes: &[u8]) -> u64 {
+    bytes.iter().fold(0u64, |acc, &b| (acc << 8) | b as u64)
+}
+
+pub fn decode_float(bytes: &[u8; 8]) -> f64 {
+    let ordered = u64::from_be_bytes(*bytes);
+    let top = 1u64 << 63;
+    f64::from_bits(if ordered & top != 0 { ordered ^ top } else { !ordered })
+}
+
+/// Undoes the 0x00 escape and drops the terminator.
+pub fn decode_string(bytes: &[u8]) -> Option<Vec<u8>> {
+    let body = bytes.strip_suffix(&[0x00, 0x00])?;
+    let mut out = Vec::with_capacity(body.len());
+    let mut i = 0;
+    while i < body.len() {
+        out.push(body[i]);
+        // A real 0x00 is written 0x00 0xff; nothing else follows one.
+        i += if body[i] == 0 { 2 } else { 1 };
+    }
+    Some(out)
+}
+
+/// How wide one column's encoding is, so an encoded tuple can be split back
+/// into its columns without the values themselves.
+///
+/// A range on a column that is not the first still has to be checked, and the
+/// entry key already carries every column -- reading it back out of the key is
+/// what stops the check from fetching the row.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Width {
+    Fixed(usize),
+    Str,
+    Vector,
+}
+
+/// Where each column's encoding starts and ends, tag included, so a span is
+/// directly comparable with `encode(&[value])`.
+pub fn column_spans(encoded: &[u8], widths: &[Width]) -> Option<Vec<(usize, usize)>> {
+    let mut at = 0usize;
+    let mut out = Vec::with_capacity(widths.len());
+    for w in widths {
+        let start = at;
+        match *encoded.get(at)? {
+            TAG_NULL | TAG_NULL_FIRST => at += 1,
+            tag @ (TAG_PRESENT | TAG_PRESENT_DESC) => {
+                at += 1;
+                // A descending column's bytes are inverted, terminator and
+                // escape included, so the walk looks for their inverses.
+                let inv = tag == TAG_PRESENT_DESC;
+                at = match w {
+                    Width::Fixed(n) => at + n,
+                    Width::Str => string_end(encoded, at, inv)?,
+                    Width::Vector => vector_end(encoded, at, inv)?,
+                };
+            }
+            _ => return None,
+        }
+        if at > encoded.len() {
+            return None;
+        }
+        out.push((start, at));
+    }
+    Some(out)
+}
+
+/// Past the `00 00` that ends a string, skipping the `00 ff` escape.
+fn string_end(b: &[u8], mut at: usize, inv: bool) -> Option<usize> {
+    let (zero, esc) = if inv { (0xff, 0x00) } else { (0x00, 0xff) };
+    loop {
+        let (x, y) = (*b.get(at)?, b.get(at + 1).copied());
+        if x == zero {
+            if y == Some(zero) {
+                return Some(at + 2);
+            } else if y == Some(esc) {
+                at += 2;
+            } else {
+                return None;
+            }
+        } else {
+            at += 1;
+        }
+    }
+}
+
+/// Past a vector: a four-byte element count, then eight bytes an element.
+fn vector_end(b: &[u8], at: usize, inv: bool) -> Option<usize> {
+    let mut n: [u8; 4] = b.get(at..at + 4)?.try_into().ok()?;
+    if inv {
+        for x in &mut n {
+            *x = !*x;
+        }
+    }
+    Some(at + 4 + u32::from_be_bytes(n) as usize * 8)
+}
+
+#[cfg(test)]
+pub fn encode(cols: &[Col<'_>]) -> Vec<u8> {
+    encode_with(cols, &[])
+}
+
+/// `opts` is per column; a column past its end is `ASC NULLS LAST`.
+pub fn encode_with(cols: &[Col<'_>], opts: &[ColOpt]) -> Vec<u8> {
+    let mut out = Vec::new();
+    for (i, c) in cols.iter().enumerate() {
+        encode_col(c, opts.get(i).copied().unwrap_or_default(), &mut out);
+    }
+    out
+}
+
+/// The tuple's place in the key. Hex is what delivers the module doc's three
+/// invariants -- no 0x00, no 0xff, no `/` inside the tuple -- and it keeps
+/// bytewise order. The table AM builds its bounds out of the same digits.
+pub fn hex_into(bytes: &[u8], out: &mut Vec<u8>) {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    for &b in bytes {
+        out.push(HEX[(b >> 4) as usize]);
+        out.push(HEX[(b & 0xf) as usize]);
+    }
+}
+
+/// The inverse: `None` if the digits are not a whole number of hex pairs.
+pub fn unhex(hex: &[u8]) -> Option<Vec<u8>> {
+    if hex.len() % 2 != 0 {
+        return None;
+    }
+    let digit = |b: u8| (b as char).to_digit(16).map(|d| d as u8);
+    hex.chunks(2).map(|p| Some(digit(p[0])? << 4 | digit(p[1])?)).collect()
+}
+
+fn too_long(len: usize) -> io::Error {
+    io::Error::other(format!(
+        "objkv: index row size {len} exceeds maximum {MAX_ENCODED} for an objkv index"
+    ))
+}
+
+/// Whether a unique entry is keyed on the value alone: only with no NULL,
+/// since Postgres allows any number of NULLs in a unique column.
+fn unique_on_value_alone(unique: bool, cols: &[Col<'_>]) -> bool {
+    unique && !cols.iter().any(Col::is_null)
+}
+
+/// `entry_key_with` at the default options, for tests.
+#[cfg(test)]
+pub fn entry_key(
+    db: u32,
+    index_id: u32,
+    cols: &[Col<'_>],
+    rowid: u64,
+    unique: bool,
+) -> io::Result<Vec<u8>> {
+    entry_key_with(db, index_id, cols, &[], rowid, unique)
+}
+
+/// The key an entry is stored under, which is also what conflict detection
+/// matches on.
+///
+/// A unique index keys on the value alone, so two *concurrent* transactions
+/// inserting it write the same key and the conflict detector refuses the
+/// later one. That is the concurrent half of uniqueness; a serial duplicate
+/// -- the first entry already committed and visible -- is a plain overwrite
+/// at this layer, and is caught by the read check in `objkv_index::insert`.
+/// A non-unique index adds the rowid, since sharing a value is normal there.
+pub fn entry_key_with(
+    db: u32,
+    index_id: u32,
+    cols: &[Col<'_>],
+    opts: &[ColOpt],
+    rowid: u64,
+    unique: bool,
+) -> io::Result<Vec<u8>> {
+    let encoded = encode_with(cols, opts);
+    if encoded.len() > MAX_ENCODED {
+        return Err(too_long(encoded.len()));
+    }
+    let mut key = Vec::with_capacity(20 + encoded.len() * 2 + 17);
+    key.extend_from_slice(index_prefix(db, index_id, unique).as_slice());
+    hex_into(&encoded, &mut key);
+    if !unique_on_value_alone(unique, cols) {
+        key.extend_from_slice(format!("/{rowid:016x}").as_bytes());
+    }
+    Ok(key)
+}
+
+/// Every entry of one index, for a full scan or a drop. `db` scopes it: oids
+/// repeat across databases, and without it two of them would overwrite each
+/// other's entries with no error anywhere.
+pub fn index_prefix(db: u32, index_id: u32, unique: bool) -> Vec<u8> {
+    let mut p = Vec::new();
+    p.extend_from_slice(format!("{db:08x}/").as_bytes());
+    p.push(if unique { b'u' } else { b'i' });
+    p.extend_from_slice(format!("/{index_id:08x}/").as_bytes());
+    p
+}
+
+/// `seek_prefix_with` at the default options, for tests.
+#[cfg(test)]
+pub fn seek_prefix(
+    db: u32,
+    index_id: u32,
+    cols: &[Col<'_>],
+    unique: bool,
+) -> io::Result<Vec<u8>> {
+    seek_prefix_with(db, index_id, cols, &[], unique)
+}
+
+/// Where a scan starts for an exact value or a leading-column prefix.
+pub fn seek_prefix_with(
+    db: u32,
+    index_id: u32,
+    cols: &[Col<'_>],
+    opts: &[ColOpt],
+    unique: bool,
+) -> io::Result<Vec<u8>> {
+    let encoded = encode_with(cols, opts);
+    if encoded.len() > MAX_ENCODED {
+        return Err(too_long(encoded.len()));
+    }
+    let mut p = index_prefix(db, index_id, unique);
+    hex_into(&encoded, &mut p);
+    Ok(p)
+}
+
+pub fn payload(rowid: u64) -> Vec<u8> {
+    rowid.to_be_bytes().to_vec()
+}
+
+fn payload_rowid(payload: &[u8]) -> Option<u64> {
+    Some(u64::from_be_bytes(payload.try_into().ok()?))
+}
+
+/// The rowid an entry points at, from the key or from the payload.
+pub fn rowid_of(key: &[u8], payload: &[u8]) -> Option<u64> {
+    let fields = key.iter().filter(|&&b| b == b'/').count() + 1;
+    if fields >= 5 {
+        if let Some(id) = key
+            .rsplit(|&b| b == b'/')
+            .next()
+            .filter(|tail| tail.len() == 16)
+            .and_then(|tail| std::str::from_utf8(tail).ok())
+            .and_then(|tail| u64::from_str_radix(tail, 16).ok())
+        {
+            return Some(id);
+        }
+    }
+    payload_rowid(payload)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct EntryRef {
+    pub db: u32,
+    pub index: u32,
+    pub rowid: u64,
+}
+
+/// Reads an entry key back, or `None` if it is not one. Deciding from the key
+/// alone is what keeps the collector free of catalog lookups, which it must be
+/// while holding the storage lock a catalog read would want.
+pub fn entry_of(key: &[u8], payload: &[u8]) -> Option<EntryRef> {
+    let mut fields = key.split(|&b| b == b'/');
+    let db = hex32(fields.next()?)?;
+    // `u` or `i` in the second field: a row key has a relation oid there.
+    match fields.next()? {
+        b"u" | b"i" => {}
+        _ => return None,
+    }
+    let index = hex32(fields.next()?)?;
+    Some(EntryRef { db, index, rowid: rowid_of(key, payload)? })
+}
+
+fn hex32(field: &[u8]) -> Option<u32> {
+    if field.len() != 8 {
+        return None;
+    }
+    u32::from_str_radix(std::str::from_utf8(field).ok()?, 16).ok()
+}
+
+pub fn row_key_of(e: &EntryRef, relid: u32) -> Vec<u8> {
+    format!("{:08x}/{relid:08x}/{:016x}", e.db, e.rowid).into_bytes()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const DB: u32 = 0x2a;
+
+    fn enc(cols: &[Col<'_>]) -> Vec<u8> {
+        encode(cols)
+    }
+
+    fn assert_sorted(name: &str, values: &[Col<'_>]) {
+        for w in values.windows(2) {
+            assert!(
+                enc(&[w[0]]) < enc(&[w[1]]),
+                "{name}: {:?} must encode below {:?}",
+                w[0],
+                w[1]
+            );
+        }
+    }
+
+    #[test]
+    fn values_come_back_out_of_the_key() {
+        for v in [i64::MIN, -1, 0, 1, i64::MAX] {
+            let e = enc(&[Col::Int8(v)]);
+            assert_eq!(decode_int(&e[1..]), v, "int8 {v}");
+        }
+        for v in [i32::MIN, -1, 0, 7, i32::MAX] {
+            let e = enc(&[Col::Int4(v)]);
+            assert_eq!(decode_int(&e[1..]) as i32, v, "int4 {v}");
+        }
+        for v in [0u32, 1, u32::MAX] {
+            let e = enc(&[Col::Oid(v)]);
+            assert_eq!(decode_uint(&e[1..]) as u32, v, "oid {v}");
+        }
+        for v in [f64::NEG_INFINITY, -1.5, 0.0, 1e308, f64::INFINITY] {
+            let e = enc(&[Col::Float8(v)]);
+            let b: [u8; 8] = e[1..].try_into().unwrap();
+            assert_eq!(decode_float(&b), v, "float8 {v}");
+        }
+        assert!(decode_float(&enc(&[Col::Float8(f64::NAN)])[1..].try_into().unwrap()).is_nan());
+        // A 0x00 inside a string is the case the escape exists for.
+        for v in [&b""[..], b"a", b"hello", b"a\x00b", b"\x00\x00", b"\xff\x00"] {
+            let e = enc(&[Col::Text(v)]);
+            assert_eq!(decode_string(&e[1..]).as_deref(), Some(v), "text {v:?}");
+        }
+    }
+
+    #[test]
+    fn floats_sort_across_zero_and_infinity() {
+        assert_sorted(
+            "float8",
+            &[
+                Col::Float8(f64::NEG_INFINITY),
+                Col::Float8(-1e308),
+                Col::Float8(-1.5),
+                Col::Float8(-f64::MIN_POSITIVE),
+                Col::Float8(0.0),
+                Col::Float8(f64::MIN_POSITIVE),
+                Col::Float8(1.5),
+                Col::Float8(1e308),
+                Col::Float8(f64::INFINITY),
+                Col::Float8(f64::NAN),
+            ],
+        );
+        // Single precision rides the same key, widened exactly.
+        assert_sorted(
+            "float4 widened",
+            &[
+                Col::Float8(f32::NEG_INFINITY as f64),
+                Col::Float8(-1.5f32 as f64),
+                Col::Float8(0.0),
+                Col::Float8(1.5f32 as f64),
+                Col::Float8(f32::INFINITY as f64),
+                Col::Float8(f32::NAN as f64),
+            ],
+        );
+        // A NULL still sorts above everything, NaN included.
+        assert!(enc(&[Col::Float8(f64::NAN)]) < enc(&[Col::Null]));
+    }
+
+    #[test]
+    fn the_two_zeros_and_every_nan_are_one_key() {
+        // Postgres compares -0 = 0 and NaN = NaN, so a unique index must not
+        // accept both spellings of either.
+        assert_eq!(enc(&[Col::Float8(-0.0)]), enc(&[Col::Float8(0.0)]));
+        let other_nan = f64::from_bits(f64::NAN.to_bits() | 0x3);
+        assert!(other_nan.is_nan());
+        assert_eq!(enc(&[Col::Float8(other_nan)]), enc(&[Col::Float8(f64::NAN)]));
+        assert_eq!(enc(&[Col::Float8(-f64::NAN)]), enc(&[Col::Float8(f64::NAN)]));
+    }
+
+    #[test]
+    fn floats_are_fixed_width() {
+        assert_eq!(enc(&[Col::Float8(1.0)]).len(), 9, "tag + 8");
+    }
+
+    #[test]
+    fn integers_sort_across_zero() {
+        assert_sorted(
+            "int4",
+            &[
+                Col::Int4(i32::MIN),
+                Col::Int4(-2),
+                Col::Int4(-1),
+                Col::Int4(0),
+                Col::Int4(1),
+                Col::Int4(i32::MAX),
+            ],
+        );
+        assert_sorted("int2", &[Col::Int2(i16::MIN), Col::Int2(-1), Col::Int2(0), Col::Int2(i16::MAX)]);
+        assert_sorted("int8", &[Col::Int8(i64::MIN), Col::Int8(-1), Col::Int8(0), Col::Int8(i64::MAX)]);
+    }
+
+    #[test]
+    fn integers_are_fixed_width() {
+        for v in [i32::MIN, -1, 0, 7, i32::MAX] {
+            assert_eq!(enc(&[Col::Int4(v)]).len(), 5, "tag + 4");
+        }
+        assert_eq!(enc(&[Col::Int2(0)]).len(), 3);
+        assert_eq!(enc(&[Col::Int8(0)]).len(), 9);
+    }
+
+    #[test]
+    fn text_sorts_bytewise_including_embedded_nuls() {
+        assert_sorted(
+            "text",
+            &[
+                Col::Text(b""),
+                Col::Text(b"a"),
+                Col::Text(b"a\x00"),
+                Col::Text(b"a\x00b"),
+                Col::Text(b"ab"),
+                Col::Text(b"b"),
+            ],
+        );
+    }
+
+    #[test]
+    fn a_prefix_sorts_before_what_extends_it() {
+        // The escape scheme's job: the terminator must be lower than any
+        // continuation, including one starting with 0x00.
+        for (short, long) in [
+            (&b""[..], &b"\x00"[..]),
+            (&b"x"[..], &b"x\x00"[..]),
+            (&b"x"[..], &b"xy"[..]),
+            (&b"\x00"[..], &b"\x00\x00"[..]),
+        ] {
+            assert!(
+                enc(&[Col::Text(short)]) < enc(&[Col::Text(long)]),
+                "{short:?} must encode below {long:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn nulls_sort_last_and_bools_and_uuids_sort_right() {
+        assert!(enc(&[Col::Int4(i32::MAX)]) < enc(&[Col::Null]));
+        assert!(enc(&[Col::Text(&[0xff; 8])]) < enc(&[Col::Null]));
+        assert_sorted("bool", &[Col::Bool(false), Col::Bool(true)]);
+
+        let lo = [0u8; 16];
+        let mut hi = [0u8; 16];
+        hi[15] = 1;
+        assert!(enc(&[Col::Uuid(&lo)]) < enc(&[Col::Uuid(&hi)]));
+    }
+
+    #[test]
+    fn the_first_column_decides() {
+        // Lexicographic in the columns, which a leading-column seek depends on.
+        let a = enc(&[Col::Int4(1), Col::Text(b"zzz")]);
+        let b = enc(&[Col::Int4(2), Col::Text(b"aaa")]);
+        assert!(a < b);
+
+        let a = enc(&[Col::Int4(1), Col::Text(b"aaa")]);
+        let b = enc(&[Col::Int4(1), Col::Text(b"aab")]);
+        assert!(a < b);
+
+        let p = seek_prefix(DB, 9, &[Col::Int4(1)], false).unwrap();
+        let k = entry_key(DB, 9, &[Col::Int4(1), Col::Text(b"anything")], 3, false).unwrap();
+        assert!(k.starts_with(&p));
+    }
+
+    #[test]
+    fn a_unique_key_ignores_the_rowid_so_duplicates_collide() {
+        // The uniqueness mechanism: if these two keys differ, two concurrent
+        // inserts of one value both commit.
+        let a = entry_key(DB, 1, &[Col::Text(b"bob")], 10, true).unwrap();
+        let b = entry_key(DB, 1, &[Col::Text(b"bob")], 999, true).unwrap();
+        assert_eq!(a, b, "a unique entry must not depend on which row it came from");
+
+        let c = entry_key(DB, 1, &[Col::Text(b"carol")], 10, true).unwrap();
+        assert_ne!(a, c);
+    }
+
+    #[test]
+    fn a_nonunique_key_keeps_the_rowid_so_duplicates_do_not_collide() {
+        let a = entry_key(DB, 1, &[Col::Text(b"bob")], 10, false).unwrap();
+        let b = entry_key(DB, 1, &[Col::Text(b"bob")], 999, false).unwrap();
+        assert_ne!(a, b, "many rows share a value; that is not a conflict");
+        assert_eq!(rowid_of(&a, &[]), Some(10));
+    }
+
+    #[test]
+    fn null_entries_in_a_unique_index_keep_their_rowid() {
+        let a = entry_key(DB, 1, &[Col::Null], 10, true).unwrap();
+        let b = entry_key(DB, 1, &[Col::Null], 11, true).unwrap();
+        assert_ne!(a, b);
+        assert_eq!(rowid_of(&a, &[]), Some(10));
+
+        let a = entry_key(DB, 1, &[Col::Int4(1), Col::Null], 10, true).unwrap();
+        let b = entry_key(DB, 1, &[Col::Int4(1), Col::Null], 11, true).unwrap();
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn the_two_unique_shapes_cannot_be_mistaken_for_one_another() {
+        // The two shapes could only collide if one tuple were both NULL-containing
+        // and not, which the NULL tag rules out.
+        let with_null = entry_key(DB, 1, &[Col::Null], 10, true).unwrap();
+        let without = entry_key(DB, 1, &[Col::Text(b"bob")], 10, true).unwrap();
+        assert!(!with_null.starts_with(&without));
+        assert!(!without.starts_with(&with_null));
+        assert_eq!(rowid_of(&without, &payload(42)), Some(42));
+    }
+
+    #[test]
+    fn bpchar_ignores_its_padding_and_orders_as_text() {
+        // `'a'::char(3)` is stored as `a  `; bpcharcmp says it equals `'a'`.
+        // The bound arrives unpadded (typmod -1) and the entry padded, and the
+        // two must meet on one key.
+        assert_eq!(enc(&[Col::Bpchar(b"a  ")]), enc(&[Col::Bpchar(b"a")]));
+        assert_eq!(enc(&[Col::Bpchar(b"a  ")]), enc(&[Col::Text(b"a")]));
+        assert_eq!(enc(&[Col::Bpchar(b"   ")]), enc(&[Col::Bpchar(b"")]));
+        // Only trailing blanks go; an inner one is part of the value.
+        assert_ne!(enc(&[Col::Bpchar(b"a b")]), enc(&[Col::Bpchar(b"ab")]));
+        assert_eq!(enc(&[Col::Bpchar(b"a b ")]), enc(&[Col::Text(b"a b")]));
+        // And a multibyte value padded to its width: `c3 a9 20` is `é`.
+        assert_eq!(enc(&[Col::Bpchar(b"\xc3\xa9 ")]), enc(&[Col::Text(b"\xc3\xa9")]));
+        assert_sorted(
+            "bpchar",
+            &[Col::Bpchar(b"a   "), Col::Bpchar(b"a b "), Col::Bpchar(b"ab  "), Col::Bpchar(b"b   ")],
+        );
+        let widths = [Width::Str];
+        let e = enc(&[Col::Bpchar(b"hi  ")]);
+        let (a, b) = column_spans(&e, &widths).unwrap()[0];
+        assert_eq!(decode_string(&e[a + 1..b]).unwrap(), b"hi", "the trimmed value is what the key holds");
+    }
+
+    #[test]
+    fn vectors_sort_by_length_first_as_btoidvectorcmp_does() {
+        // btoidvectorcmp returns the length difference before looking at any
+        // element, so (2) < (1,2) even though 2 > 1.
+        assert_sorted(
+            "oidvector",
+            &[
+                Col::Vector(&[]),
+                Col::Vector(&[2]),
+                Col::Vector(&[1, 2]),
+                Col::Vector(&[1, 3]),
+                Col::Vector(&[2, 0]),
+                Col::Vector(&[0, 0, 0]),
+            ],
+        );
+        // Prefix-free: a vector's key is never a prefix of a longer one's, so
+        // a following column cannot bleed into the comparison.
+        let short = enc(&[Col::Vector(&[1]), Col::Int4(i32::MAX)]);
+        let long = enc(&[Col::Vector(&[1, 0]), Col::Int4(i32::MIN)]);
+        assert!(short < long);
+        let widths = [Width::Vector, Width::Fixed(4)];
+        let spans = column_spans(&long, &widths).unwrap();
+        assert_eq!(spans[0], (0, 1 + 4 + 16));
+        assert_eq!(spans[1].1, long.len());
+    }
+
+    #[test]
+    fn an_oversized_key_is_refused_rather_than_truncated() {
+        // A truncated key collides with every value sharing its first
+        // MAX_ENCODED bytes.
+        let big = vec![b'x'; MAX_ENCODED + 1];
+        let err = entry_key(DB, 1, &[Col::Text(&big)], 1, false).unwrap_err();
+        assert!(err.to_string().contains("exceeds maximum"), "{err}");
+        assert!(entry_key(DB, 1, &[Col::Text(&big[..MAX_ENCODED - 3])], 1, false).is_ok());
+    }
+
+    #[test]
+    fn oids_sort_as_unsigned() {
+        // An oid is unsigned: 4000000000 is above 1. Flipping a sign bit, as the
+        // signed integers need, would misorder half the catalog.
+        assert_sorted(
+            "oid",
+            &[Col::Oid(0), Col::Oid(1), Col::Oid(16384), Col::Oid(2_147_483_648), Col::Oid(u32::MAX)],
+        );
+        assert_eq!(enc(&[Col::Oid(0)]).len(), 5, "tag plus a fixed four bytes");
+    }
+
+    #[test]
+    fn names_sort_as_strings_and_ignore_their_padding() {
+        // A `name` is NUL-padded to 64 bytes, and the padding is not part of the
+        // value: "ab" padded differently is the same name.
+        let mut padded = b"pg_class".to_vec();
+        padded.resize(64, 0);
+        assert_eq!(enc(&[Col::Name(&padded)]), enc(&[Col::Name(b"pg_class")]));
+
+        assert_sorted(
+            "name",
+            &[Col::Name(b"pg_am"), Col::Name(b"pg_class"), Col::Name(b"pg_classes"), Col::Name(b"pg_proc")],
+        );
+        // Names and text order together, since the catalogs mix them freely.
+        assert_eq!(enc(&[Col::Name(b"pg_class")]), enc(&[Col::Text(b"pg_class")]));
+    }
+
+    #[test]
+    fn a_critical_index_key_round_trips() {
+        // (oid, smallint), the shape most catalog lookups take.
+        let a = entry_key(DB, 1, &[Col::Oid(1259), Col::Int2(1)], 0, true).unwrap();
+        let b = entry_key(DB, 1, &[Col::Oid(1259), Col::Int2(2)], 0, true).unwrap();
+        let c = entry_key(DB, 1, &[Col::Oid(1260), Col::Int2(1)], 0, true).unwrap();
+        assert!(a < b && b < c);
+        let p = seek_prefix(DB, 1, &[Col::Oid(1259)], true).unwrap();
+        assert!(a.starts_with(&p) && b.starts_with(&p) && !c.starts_with(&p));
+    }
+
+    #[test]
+    fn two_databases_never_share_a_key() {
+        // Oids repeat across databases, so without it in the key one database
+        // overwrites another's entries.
+        for unique in [true, false] {
+            let a = entry_key(1, 7, &[Col::Text(b"bob")], 10, unique).unwrap();
+            let b = entry_key(2, 7, &[Col::Text(b"bob")], 10, unique).unwrap();
+            assert_ne!(a, b, "same index oid in two databases must not collide");
+            assert!(!a.starts_with(&index_prefix(2, 7, unique)));
+            assert!(!b.starts_with(&index_prefix(1, 7, unique)));
+            assert!(a.starts_with(&index_prefix(1, 7, unique)));
+        }
+    }
+
+    #[test]
+    fn a_scan_of_one_database_cannot_reach_another() {
+        let mine = seek_prefix(1, 7, &[Col::Text(b"bob")], false).unwrap();
+        let theirs = entry_key(2, 7, &[Col::Text(b"bob")], 10, false).unwrap();
+        assert!(!theirs.starts_with(&mine));
+    }
+
+    #[test]
+    fn keys_hold_no_nul_ff_or_slash_inside_a_field() {
+        // The three invariants the readers lean on: the store resumes a scan
+        // by appending 0x00, the table AM bounds a range with a trailing 0xff,
+        // and both split fields on `/`. A tuple with all three bytes in it
+        // must not leak any of them into the key.
+        let k = entry_key(DB, 1, &[Col::Text(b"\x00\xff/hi"), Col::Null], 7, false).unwrap();
+        assert!(!k.contains(&0x00) && !k.contains(&0xff), "{}", String::from_utf8_lossy(&k));
+        assert_eq!(
+            k.iter().filter(|&&b| b == b'/').count(),
+            4,
+            "db / kind / index / tuple / rowid: {}",
+            String::from_utf8_lossy(&k)
+        );
+        // The tuple field is the hex of exactly what was encoded.
+        let tuple = k.split(|&b| b == b'/').nth(3).unwrap();
+        assert_eq!(unhex(tuple), Some(encode(&[Col::Text(b"\x00\xff/hi"), Col::Null])));
+        assert_eq!(unhex(b"abc"), None, "an odd digit count is not a tuple");
+    }
+
+    #[test]
+    fn an_encoded_tuple_splits_back_into_its_columns() {
+        let cols = [
+            Col::Int4(-5),
+            Col::Text(b"a\x00b"),
+            Col::Null,
+            Col::Oid(1259),
+            Col::Vector(&[1, 2]),
+            Col::Text(b""),
+        ];
+        let widths = [
+            Width::Fixed(4),
+            Width::Str,
+            Width::Fixed(4),
+            Width::Fixed(4),
+            Width::Vector,
+            Width::Str,
+        ];
+        let enc = encode(&cols);
+        let spans = column_spans(&enc, &widths).expect("splits");
+        assert_eq!(spans.len(), cols.len());
+        for (i, (a, b)) in spans.iter().enumerate() {
+            assert_eq!(&enc[*a..*b], encode(&[cols[i]]).as_slice(), "column {i}");
+        }
+        assert_eq!(spans.last().unwrap().1, enc.len(), "no bytes left over");
+    }
+
+    #[test]
+    fn splitting_refuses_what_it_cannot_read() {
+        let enc = encode(&[Col::Text(b"hi")]);
+        assert_eq!(column_spans(&enc[..enc.len() - 1], &[Width::Str]), None);
+        assert_eq!(column_spans(&enc, &[Width::Str, Width::Str]), None);
+        assert_eq!(column_spans(&[0x7f], &[Width::Fixed(1)]), None);
+    }
+
+    #[test]
+    fn a_column_split_off_a_key_compares_as_the_value_does() {
+        // What a range on a trailing column needs: the bytes for that column
+        // alone, ordered as the values are.
+        let lo = encode(&[Col::Int4(1), Col::Text(b"m")]);
+        let hi = encode(&[Col::Int4(1), Col::Text(b"z")]);
+        let w = [Width::Fixed(4), Width::Str];
+        let (a, b) = column_spans(&lo, &w).unwrap()[1];
+        let (c, d) = column_spans(&hi, &w).unwrap()[1];
+        assert!(lo[a..b] < hi[c..d]);
+    }
+
+    #[test]
+    fn hex_preserves_order() {
+        // What lands in the bucket is the hex, and the two orders must agree.
+        let mut prev: Option<Vec<u8>> = None;
+        for v in [i32::MIN, -9, -1, 0, 1, 9, i32::MAX] {
+            let k = entry_key(DB, 1, &[Col::Int4(v)], 0, true).unwrap();
+            if let Some(p) = prev {
+                assert!(p < k, "hex order must match value order at {v}");
+            }
+            prev = Some(k);
+        }
+    }
+
+    #[test]
+    fn descending_and_nulls_first_columns_sort_as_asked() {
+        let desc = ColOpt { desc: true, nulls_first: false };
+        let desc_nf = ColOpt { desc: true, nulls_first: true };
+        let asc_nf = ColOpt { desc: false, nulls_first: true };
+        let e = |c: Col<'_>, o: ColOpt| encode_with(&[c], &[o]);
+
+        // Integers reverse.
+        assert!(e(Col::Int4(2), desc) < e(Col::Int4(1), desc));
+        assert!(e(Col::Int4(-1), desc) > e(Col::Int4(0), desc));
+        assert!(e(Col::Int8(i64::MAX), desc) < e(Col::Int8(i64::MIN), desc));
+        // Floats too, and NaN, above everything ascending, is below it here.
+        assert!(e(Col::Float8(1.5), desc) < e(Col::Float8(-1.5), desc));
+        assert!(e(Col::Float8(f64::NAN), desc) < e(Col::Float8(f64::INFINITY), desc));
+        // A prefix sorts after what extends it, the reverse of ascending.
+        assert!(e(Col::Text(b"ab"), ASC) < e(Col::Text(b"abc"), ASC));
+        assert!(e(Col::Text(b"ab"), desc) > e(Col::Text(b"abc"), desc));
+        assert!(e(Col::Text(b"b"), desc) < e(Col::Text(b"a"), desc));
+        // An escaped zero byte keeps its place.
+        assert!(e(Col::Text(b"a\x00b"), desc) > e(Col::Text(b"a\x01"), desc));
+        assert!(e(Col::Text(b"a\x00b"), desc) < e(Col::Text(b"a"), desc));
+        let v1 = [1u64, 2];
+        let v2 = [1u64, 2, 3];
+        assert!(e(Col::Vector(&v1), desc) > e(Col::Vector(&v2), desc));
+
+        // NULL goes where the option says, whichever way the values go.
+        assert!(e(Col::Null, ASC) > e(Col::Int4(i32::MAX), ASC));
+        assert!(e(Col::Null, desc) > e(Col::Int4(i32::MIN), desc));
+        assert!(e(Col::Null, asc_nf) < e(Col::Int4(i32::MIN), asc_nf));
+        assert!(e(Col::Null, desc_nf) < e(Col::Int4(i32::MAX), desc_nf));
+    }
+
+    #[test]
+    fn spans_and_bodies_come_back_from_a_descending_key() {
+        let opts = [ColOpt { desc: true, nulls_first: true }, ColOpt { desc: true, nulls_first: false }, ASC];
+        let v = [7u64, 8];
+        let cols = [Col::Text(b"a\x00z"), Col::Vector(&v), Col::Int4(5)];
+        let enc = encode_with(&cols, &opts);
+        let spans = column_spans(&enc, &[Width::Str, Width::Vector, Width::Fixed(4)]).unwrap();
+        assert_eq!(spans.len(), 3);
+        assert_eq!(spans[2].1, enc.len(), "the spans cover the key exactly");
+        let (a, b) = spans[0];
+        let body = column_body(enc[a], &enc[a + 1..b]);
+        assert_eq!(decode_string(&body).unwrap(), b"a\x00z");
+        let (a, b) = spans[2];
+        assert_eq!(decode_int(&column_body(enc[a], &enc[a + 1..b])), 5);
+
+        let nulls = encode_with(&[Col::Null, Col::Null], &[opts[0], ASC]);
+        let spans = column_spans(&nulls, &[Width::Str, Width::Fixed(4)]).unwrap();
+        assert!(is_null_tag(nulls[spans[0].0]) && is_null_tag(nulls[spans[1].0]));
+        assert_ne!(nulls[0], nulls[1], "first and last are different tags");
+    }
+}

--- a/crates/_support/objkv/src/index_key.rs
+++ b/crates/_support/objkv/src/index_key.rs
@@ -435,6 +435,11 @@ fn payload_rowid(payload: &[u8]) -> Option<u64> {
 }
 
 /// The rowid an entry points at, from the key or from the payload.
+///
+/// `key` is the entry key as written, never the versioned form a run stores
+/// (`key::versioned`): the version suffix has the same shape as a rowid
+/// field and would be read as one. Callers that hold run keys strip them
+/// with `key::row_of` first, as the collector does.
 pub fn rowid_of(key: &[u8], payload: &[u8]) -> Option<u64> {
     let fields = key.iter().filter(|&&b| b == b'/').count() + 1;
     if fields >= 5 {
@@ -460,7 +465,8 @@ pub struct EntryRef {
 
 /// Reads an entry key back, or `None` if it is not one. Deciding from the key
 /// alone is what keeps the collector free of catalog lookups, which it must be
-/// while holding the storage lock a catalog read would want.
+/// while holding the storage lock a catalog read would want. Unversioned
+/// keys only; see `rowid_of`.
 pub fn entry_of(key: &[u8], payload: &[u8]) -> Option<EntryRef> {
     let mut fields = key.split(|&b| b == b'/');
     let db = hex32(fields.next()?)?;

--- a/crates/_support/objkv/src/key.rs
+++ b/crates/_support/objkv/src/key.rs
@@ -1,0 +1,95 @@
+//! Versioned key encoding: `<row key>/<u64::MAX - seq>`.
+//!
+//! The sequence number is inverted so a row's versions sort newest-first, which
+//! makes "read as of snapshot S" a single seek to `<row>/<MAX-S>` rather than a
+//! walk back through history.
+//!
+//! Only run files carry versioned keys. Commit objects keep bare row keys and
+//! inherit their sequence number from the commit header, because a transaction
+//! does not know its number until it has won the PUT that assigns it.
+
+/// Read the present. A smaller value reads the past.
+pub const LATEST: u64 = u64::MAX;
+
+const SUFFIX_LEN: usize = 1 + 16;
+
+pub fn versioned(row_key: &[u8], seq: u64) -> Vec<u8> {
+    let mut out = Vec::with_capacity(row_key.len() + SUFFIX_LEN);
+    out.extend_from_slice(row_key);
+    out.push(b'/');
+    out.extend_from_slice(format!("{:016x}", u64::MAX - seq).as_bytes());
+    out
+}
+
+/// Seek here to read `row_key` as of `snapshot`; the first entry at or after
+/// it is the version that was live then.
+pub fn seek_at(row_key: &[u8], snapshot: u64) -> Vec<u8> {
+    versioned(row_key, snapshot)
+}
+
+pub fn row_of(versioned_key: &[u8]) -> Option<&[u8]> {
+    if versioned_key.len() < SUFFIX_LEN {
+        return None;
+    }
+    let cut = versioned_key.len() - SUFFIX_LEN;
+    if versioned_key[cut] != b'/' {
+        return None;
+    }
+    Some(&versioned_key[..cut])
+}
+
+pub fn seq_of(versioned_key: &[u8]) -> Option<u64> {
+    if versioned_key.len() < SUFFIX_LEN {
+        return None;
+    }
+    let tail = &versioned_key[versioned_key.len() - 16..];
+    let inv = u64::from_str_radix(std::str::from_utf8(tail).ok()?, 16).ok()?;
+    Some(u64::MAX - inv)
+}
+
+pub fn belongs_to(versioned_key: &[u8], row_key: &[u8]) -> bool {
+    row_of(versioned_key) == Some(row_key)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn round_trips() {
+        let k = versioned(b"0001/0002", 7);
+        assert_eq!(row_of(&k), Some(&b"0001/0002"[..]));
+        assert_eq!(seq_of(&k), Some(7));
+        assert!(belongs_to(&k, b"0001/0002"));
+        assert!(!belongs_to(&k, b"0001/0003"));
+    }
+
+    #[test]
+    fn newer_versions_sort_first() {
+        let old = versioned(b"r", 1);
+        let mid = versioned(b"r", 5);
+        let new = versioned(b"r", 9);
+        assert!(new < mid && mid < old, "higher seq must sort earlier");
+    }
+
+    #[test]
+    fn a_seek_lands_on_the_newest_version_at_or_below_the_snapshot() {
+        let mut keys = vec![versioned(b"r", 1), versioned(b"r", 5), versioned(b"r", 9)];
+        keys.sort();
+        let probe = seek_at(b"r", 5);
+        let found = keys.iter().find(|k| **k >= probe).unwrap();
+        assert_eq!(seq_of(found), Some(5));
+
+        let probe = seek_at(b"r", 0);
+        assert!(keys.iter().find(|k| **k >= probe).is_none_or(|k| seq_of(k) == Some(0)));
+
+        let probe = seek_at(b"r", LATEST);
+        assert_eq!(seq_of(keys.iter().find(|k| **k >= probe).unwrap()), Some(9));
+    }
+
+    #[test]
+    fn an_unversioned_key_is_rejected_rather_than_misparsed() {
+        assert_eq!(row_of(b"short"), None);
+        assert_eq!(row_of(b"0001/0002"), None, "no suffix separator at the cut");
+    }
+}

--- a/crates/_support/objkv/src/lease.rs
+++ b/crates/_support/objkv/src/lease.rs
@@ -1,0 +1,692 @@
+//! The single-writer lease: which process may write to a bucket, and until
+//! when.
+//!
+//! Two processes on one bucket would each hand out the same sequence numbers
+//! and row ids and overwrite each other's rows with no error. The lease makes
+//! a second process refuse to start while the first is renewing, and lets it
+//! take over -- from any host -- once the first has stopped.
+//!
+//! Layout: `owner/<epoch>/<renewal>` objects, each created with put-if-absent.
+//! Claiming `owner/<E+1>/0` is the takeover, and exactly one claimant wins it
+//! because the key is new. The holder renews by writing `owner/<E>/<n+1>`
+//! with a fresh expiry, then lists `owner/` to see whether a higher epoch has
+//! appeared: if one has, the lease is lost and the holder stops writing.
+//!
+//! Time: the body carries an absolute expiry in unix milliseconds. A claimant
+//! takes over once that has passed on its own clock; the holder treats its
+//! lease as over `SKEW_MARGIN_MS` before the expiry it wrote. Clocks have to
+//! agree to within that margin, which is what every wall-clock lease assumes,
+//! and clean shutdowns do not depend on it at all: `release` writes a renewal
+//! that has already expired, and the next open claims at once.
+//!
+//! Epochs never repeat. The newest claim always stays in the bucket -- a
+//! release expires it rather than deleting it, and only the next claim
+//! clears it -- so every claimant counts on from the highest epoch ever
+//! taken, and an object stamped with an old epoch can always be told from
+//! the current owner's. That counting trusts the listing of `owner/`; a
+//! listing that left the newest claim out, over a leftover of an older one,
+//! would hand out an epoch already used. `db.rs` checks the claimed epoch
+//! against the fence records -- one per epoch that ever opened, never
+//! deleted -- and refuses to open under one that is not above them all.
+//!
+//! The lease alone cannot stop a writer whose clock is wrong or which was
+//! paused past its expiry from making one more PUT. That is what the epoch
+//! is for: it is stamped into every commit object, and `db.rs` records a
+//! fence at each takeover so such an object is recognised and never applied.
+
+use std::io;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::Arc;
+
+use crate::s3::PutOutcome;
+use crate::store::Store;
+
+/// How long a renewal is good for.
+pub const TTL_MS: u64 = 30_000;
+/// How often the holder renews: well inside the TTL, so one failed renewal
+/// does not cost the lease.
+pub const HEARTBEAT_MS: u64 = 10_000;
+/// How far apart two clocks may be. The holder stops this much before its
+/// written expiry, so a claimant whose clock runs ahead by less than this
+/// still cannot take over a writer that is about to PUT.
+pub const SKEW_MARGIN_MS: u64 = 5_000;
+
+/// Wall-clock time, so a test can move it by hand.
+pub trait Clock: Send + Sync {
+    fn now_ms(&self) -> u64;
+}
+
+pub struct SystemClock;
+
+impl Clock for SystemClock {
+    fn now_ms(&self) -> u64 {
+        let since = std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH);
+        since.map_or(0, |d| d.as_millis() as u64)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Owner {
+    pub host: String,
+    pub pid: u32,
+}
+
+impl Owner {
+    pub fn me() -> Owner {
+        Owner { host: hostname(), pid: std::process::id() }
+    }
+}
+
+/// What an owner object says.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Body {
+    pub owner: Owner,
+    pub expires_ms: u64,
+}
+
+impl Body {
+    /// Four lines and a checksum of them. An owner object that arrived torn
+    /// must not decode: a pid or expiry off by a digit is a live owner that
+    /// looks dead, or a dead one that looks alive for ever, and either is a
+    /// second writer. Unreadable, it is left to the operator instead.
+    pub fn encode(&self) -> Vec<u8> {
+        let text = format!("objkv-lease\n{}\n{}\n{}\n", self.owner.host, self.owner.pid, self.expires_ms);
+        let crc = crc32c::pg_comp_crc32c(0xffff_ffff, text.as_bytes()) ^ 0xffff_ffff;
+        format!("{text}crc:{crc:08x}\n").into_bytes()
+    }
+    fn decode(b: &[u8]) -> Option<Body> {
+        let s = std::str::from_utf8(b).ok()?;
+        let (text, crc_line) = s.strip_suffix('\n')?.rsplit_once('\n')?;
+        let want = u32::from_str_radix(crc_line.strip_prefix("crc:")?, 16).ok()?;
+        let text = format!("{text}\n");
+        if crc32c::pg_comp_crc32c(0xffff_ffff, text.as_bytes()) ^ 0xffff_ffff != want {
+            return None;
+        }
+        let mut it = text.lines();
+        if it.next()? != "objkv-lease" {
+            return None;
+        }
+        let body = Body {
+            owner: Owner { host: it.next()?.to_string(), pid: it.next()?.parse().ok()? },
+            expires_ms: it.next()?.parse().ok()?,
+        };
+        it.next().is_none().then_some(body)
+    }
+}
+
+pub(crate) fn key(epoch: u64, renewal: u64) -> String {
+    format!("owner/{epoch:016x}/{renewal:016x}")
+}
+
+/// `owner/<epoch>/<renewal>` -> (epoch, renewal).
+fn parse_key(k: &str) -> Option<(u64, u64)> {
+    let mut parts = k.strip_prefix("owner/")?.split('/');
+    let epoch = u64::from_str_radix(parts.next()?, 16).ok()?;
+    let renewal = u64::from_str_radix(parts.next()?, 16).ok()?;
+    parts.next().is_none().then_some((epoch, renewal))
+}
+
+/// The newest claim in the bucket.
+#[derive(Debug)]
+pub struct Held {
+    pub epoch: u64,
+    pub renewal: u64,
+    pub key: String,
+    /// `None` when the object exists but does not decode. The epoch is taken
+    /// either way; who took it and until when is the unreadable part.
+    pub body: Option<Body>,
+    /// Every `owner/` key, so a successful claim can clear the older ones.
+    keys: Vec<String>,
+}
+
+/// The newest epoch anything has claimed and its newest renewal.
+///
+/// The epoch comes from the key and the rest from the body, because they
+/// fail separately: an owner object that does not decode still proves its
+/// epoch is taken.
+pub fn current(store: &Arc<dyn Store>) -> io::Result<Option<Held>> {
+    let keys: Vec<String> = store.list("owner/")?.into_iter().map(|i| i.key).collect();
+    let Some((epoch, renewal, k)) = keys
+        .iter()
+        .filter_map(|k| parse_key(k).map(|(e, n)| (e, n, k.clone())))
+        .max()
+    else {
+        return Ok(None);
+    };
+    let body = store.get(&k)?.and_then(|b| Body::decode(&b));
+    Ok(Some(Held { epoch, renewal, key: k, body, keys }))
+}
+
+struct Inner {
+    store: Arc<dyn Store>,
+    clock: Arc<dyn Clock>,
+    epoch: u64,
+    me: Owner,
+    /// The expiry of the newest renewal that landed.
+    expires_ms: AtomicU64,
+    renewal: AtomicU64,
+    /// A higher epoch was seen in the bucket: someone took over. 0 = no.
+    lost_to: AtomicU64,
+    released: AtomicBool,
+    /// Tells the heartbeat thread to stop.
+    stop: AtomicBool,
+}
+
+/// A held lease. Cloning shares it; the heartbeat thread holds one clone.
+#[derive(Clone)]
+pub struct Lease {
+    inner: Arc<Inner>,
+}
+
+impl std::fmt::Debug for Lease {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Lease")
+            .field("epoch", &self.inner.epoch)
+            .field("expires_ms", &self.inner.expires_ms.load(Ordering::Relaxed))
+            .field("lost_to", &self.inner.lost_to.load(Ordering::Relaxed))
+            .field("released", &self.inner.released.load(Ordering::Relaxed))
+            .finish()
+    }
+}
+
+impl Lease {
+    /// Takes the lease with a real clock and a heartbeat thread renewing it.
+    pub fn acquire_with_heartbeat(store: &Arc<dyn Store>) -> io::Result<Lease> {
+        let lease = Lease::acquire(store, Arc::new(SystemClock))?;
+        let beat = lease.clone();
+        std::thread::Builder::new()
+            .name("objkv-lease".into())
+            .spawn(move || beat.heartbeat())
+            .map_err(|e| io::Error::other(format!("objkv: cannot start the lease heartbeat: {e}")))?;
+        Ok(lease)
+    }
+
+    /// Takes the lease, or explains why it cannot. No heartbeat: the caller
+    /// renews, which is what a test with a fake clock wants.
+    pub fn acquire(store: &Arc<dyn Store>, clock: Arc<dyn Clock>) -> io::Result<Lease> {
+        let me = Owner::me();
+        for _ in 0..8 {
+            let held = current(store)?;
+            let now = clock.now_ms();
+            let next = held.as_ref().map_or(1, |h| h.epoch + 1);
+            if let Some(h) = &held {
+                match &h.body {
+                    // An owner object this version cannot read is never assumed
+                    // expired: a live server and a corrupt object look the same.
+                    None => {
+                        return Err(io::Error::other(format!(
+                            "this bucket is owned by a lease this version cannot read \\
+                             (`{}`). If that server is definitely gone, delete the object \\
+                             and start again.",
+                            h.key
+                        )))
+                    }
+                    // A same-host owner whose pid is gone crashed: no need to
+                    // wait out its lease. (A pid namespace can make a live
+                    // owner look gone; the epoch check on every PUT is the
+                    // defence for that case.)
+                    Some(b) if now <= b.expires_ms && b.owner != me && !same_host_dead(&b.owner, &me) => {
+                        return Err(io::Error::other(format!(
+                            "this bucket is owned by {}:{} (lease epoch {}, valid for another \\
+                             {} ms). Two servers sharing one bucket would overwrite each \\
+                             other's rows. A server that stops renewing is taken over \\
+                             automatically once its lease expires.",
+                            b.owner.host,
+                            b.owner.pid,
+                            h.epoch,
+                            b.expires_ms - now
+                        )))
+                    }
+                    // Expired, or our own process reopening: take over.
+                    Some(_) => {}
+                }
+            }
+            let expires_ms = now + TTL_MS;
+            let body = Body { owner: me.clone(), expires_ms };
+            // Losing this means someone claimed the same epoch first; look again.
+            if store.put_if_absent(&key(next, 0), &body.encode())? == PutOutcome::Written {
+                // Older claims are garbage now. Best effort: a leftover is
+                // one more key in the next listing, nothing else.
+                if let Some(h) = held {
+                    for k in h.keys {
+                        let _ = store.delete(&k);
+                    }
+                }
+                return Ok(Lease {
+                    inner: Arc::new(Inner {
+                        store: Arc::clone(store),
+                        clock,
+                        epoch: next,
+                        me,
+                        expires_ms: AtomicU64::new(expires_ms),
+                        renewal: AtomicU64::new(0),
+                        lost_to: AtomicU64::new(0),
+                        released: AtomicBool::new(false),
+                        stop: AtomicBool::new(false),
+                    }),
+                });
+            }
+        }
+        Err(io::Error::other("could not claim the objkv lease; too many claimants competing"))
+    }
+
+    pub fn epoch(&self) -> u64 {
+        self.inner.epoch
+    }
+
+    pub fn expires_ms(&self) -> u64 {
+        self.inner.expires_ms.load(Ordering::Acquire)
+    }
+
+    /// Whether this process may write right now: not released, not taken
+    /// over, and the newest renewal has more than the skew margin left.
+    pub fn valid(&self) -> bool {
+        self.why_invalid().is_none()
+    }
+
+    /// `None` when valid; otherwise what a fence message should say.
+    pub fn why_invalid(&self) -> Option<String> {
+        let i = &self.inner;
+        if i.released.load(Ordering::Acquire) {
+            return Some(format!("the lease (epoch {}) was released", i.epoch));
+        }
+        let lost = i.lost_to.load(Ordering::Acquire);
+        if lost != 0 {
+            return Some(format!(
+                "the lease (epoch {}) was taken over by epoch {lost}; another server owns \\
+                 the bucket now",
+                i.epoch
+            ));
+        }
+        let now = i.clock.now_ms();
+        let expires = i.expires_ms.load(Ordering::Acquire);
+        if now + SKEW_MARGIN_MS >= expires {
+            return Some(format!(
+                "the lease (epoch {}) expired: last renewed to {expires} ms, now {now} ms; \\
+                 another server may own the bucket",
+                i.epoch
+            ));
+        }
+        None
+    }
+
+    /// `Ok` while writing is allowed.
+    pub fn check(&self) -> io::Result<()> {
+        match self.why_invalid() {
+            Some(why) => Err(io::Error::other(format!("objkv: {why}"))),
+            None => Ok(()),
+        }
+    }
+
+    /// Writes the next renewal, then looks for a takeover. Either failure
+    /// leaves the lease as it was; an expiry that is not renewed in time
+    /// simply runs out.
+    pub fn renew(&self) -> io::Result<()> {
+        let i = &self.inner;
+        if i.released.load(Ordering::Acquire) {
+            return Err(io::Error::other("objkv: the lease was released"));
+        }
+        if let Some(why) = self.why_invalid() {
+            // Once expired or lost the lease is not renewed: the takeover
+            // window belongs to the claimants, and writing a fresh expiry
+            // into it would let a paused writer come back to life.
+            return Err(io::Error::other(format!("objkv: not renewing: {why}")));
+        }
+        let now = i.clock.now_ms();
+        let n = i.renewal.load(Ordering::Acquire) + 1;
+        let expires_ms = now + TTL_MS;
+        let body = Body { owner: i.me.clone(), expires_ms };
+        match i.store.put_if_absent(&key(i.epoch, n), &body.encode())? {
+            PutOutcome::Written => {}
+            // Only this process writes under its epoch, so an existing
+            // object is our own, from an attempt whose response was lost.
+            PutOutcome::AlreadyExists => {
+                let found = i.store.get(&key(i.epoch, n))?.and_then(|b| Body::decode(&b));
+                match found {
+                    Some(b) if b.owner == i.me => {
+                        i.expires_ms.fetch_max(b.expires_ms, Ordering::AcqRel);
+                        i.renewal.store(n, Ordering::Release);
+                        let _ = i.store.delete(&key(i.epoch, n - 1));
+                        return self.check_takeover();
+                    }
+                    _ => {
+                        return Err(io::Error::other(format!(
+                            "objkv: renewal object `{}` exists and is not ours",
+                            key(i.epoch, n)
+                        )))
+                    }
+                }
+            }
+        }
+        i.expires_ms.fetch_max(expires_ms, Ordering::AcqRel);
+        i.renewal.store(n, Ordering::Release);
+        let _ = i.store.delete(&key(i.epoch, n - 1));
+        self.check_takeover()
+    }
+
+    fn check_takeover(&self) -> io::Result<()> {
+        let i = &self.inner;
+        if let Some(h) = current(&i.store)? {
+            if h.epoch > i.epoch {
+                i.lost_to.fetch_max(h.epoch, Ordering::AcqRel);
+                return Err(io::Error::other(format!(
+                    "objkv: the lease (epoch {}) was taken over by epoch {}",
+                    i.epoch, h.epoch
+                )));
+            }
+        }
+        Ok(())
+    }
+
+    /// Gives the lease up: the next open, on any host, claims at once. Every
+    /// write is refused from here on.
+    ///
+    /// The claim is expired, not deleted: a renewal whose expiry is already
+    /// past goes in as the newest object under this epoch, so the epoch
+    /// stays visible (and is never handed out again) until the next claim
+    /// supersedes it. A renewal already on the wire when this runs can land
+    /// after it, which costs the next open a wait of at most the TTL; the
+    /// heartbeat checks `released` before each renewal, so that needs the
+    /// two to cross within one round trip.
+    pub fn release(&self) -> io::Result<()> {
+        let i = &self.inner;
+        i.stop.store(true, Ordering::Release);
+        if i.released.swap(true, Ordering::AcqRel) {
+            return Ok(());
+        }
+        if i.lost_to.load(Ordering::Acquire) != 0 {
+            return Ok(()); // the next epoch's claim has superseded ours already
+        }
+        let n = i.renewal.load(Ordering::Acquire) + 1;
+        let body = Body { owner: i.me.clone(), expires_ms: 0 };
+        // The previous object goes only once the new one is known to be
+        // there: a store that reports "exists" for an object it does not hold
+        // would otherwise leave this epoch with no object at all, and the
+        // next claimant counting on from whatever older leftover it lists.
+        if i.store.put_if_absent(&key(i.epoch, n), &body.encode())? == PutOutcome::AlreadyExists
+            && i.store.get(&key(i.epoch, n))?.is_none()
+        {
+            return Err(io::Error::other(format!(
+                "objkv: release: `{}` was reported to exist but is not there; the claim is left to expire",
+                key(i.epoch, n)
+            )));
+        }
+        i.renewal.store(n, Ordering::Release);
+        i.expires_ms.store(0, Ordering::Release);
+        i.store.delete(&key(i.epoch, n - 1))
+    }
+
+    /// Stops the heartbeat without releasing: for a process that has been
+    /// fenced and must not touch the bucket again.
+    pub fn stop_heartbeat(&self) {
+        self.inner.stop.store(true, Ordering::Release);
+    }
+
+    fn heartbeat(self) {
+        const SLICE_MS: u64 = 250;
+        loop {
+            for _ in 0..HEARTBEAT_MS / SLICE_MS {
+                if self.inner.stop.load(Ordering::Acquire) {
+                    return;
+                }
+                std::thread::sleep(std::time::Duration::from_millis(SLICE_MS));
+            }
+            if self.inner.released.load(Ordering::Acquire) {
+                return;
+            }
+            if let Err(e) = self.renew() {
+                eprintln!("objkv lease: renewal failed: {e}");
+                if self.inner.lost_to.load(Ordering::Acquire) != 0 {
+                    return;
+                }
+            }
+        }
+    }
+}
+
+/// True when `owner` is a process on this host that no longer exists.
+fn same_host_dead(owner: &Owner, me: &Owner) -> bool {
+    if owner.host != me.host || owner.pid == 0 {
+        return false;
+    }
+    let rc = unsafe { libc::kill(owner.pid as libc::pid_t, 0) };
+    rc != 0 && std::io::Error::last_os_error().raw_os_error() == Some(libc::ESRCH)
+}
+
+fn hostname() -> String {
+    // libc::c_char, not i8: it is unsigned on aarch64 Linux among others, and
+    // a hard-coded i8 array will not compile there.
+    let mut buf = [0 as libc::c_char; 256];
+    // SAFETY: buf is a valid writable array of the length passed.
+    let rc = unsafe { libc::gethostname(buf.as_mut_ptr(), buf.len()) };
+    if rc != 0 {
+        return "unknown".into();
+    }
+    let bytes: Vec<u8> = buf.iter().take_while(|&&c| c != 0).map(|&c| c as u8).collect();
+    String::from_utf8_lossy(&bytes).into_owned()
+}
+
+#[cfg(test)]
+pub(crate) mod testing {
+    use super::*;
+
+    /// A clock a test moves by hand.
+    #[derive(Default)]
+    pub struct FakeClock(pub AtomicU64);
+
+    impl FakeClock {
+        pub fn at(ms: u64) -> Arc<FakeClock> {
+            Arc::new(FakeClock(AtomicU64::new(ms)))
+        }
+        pub fn advance(&self, ms: u64) {
+            self.0.fetch_add(ms, Ordering::SeqCst);
+        }
+        pub fn set(&self, ms: u64) {
+            self.0.store(ms, Ordering::SeqCst);
+        }
+    }
+
+    impl Clock for FakeClock {
+        fn now_ms(&self) -> u64 {
+            self.0.load(Ordering::SeqCst)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::testing::FakeClock;
+    use super::*;
+    use crate::store::MemStore;
+
+    fn store() -> Arc<dyn Store> {
+        Arc::new(MemStore::new()) as Arc<dyn Store>
+    }
+
+    fn foreign(expires_ms: u64) -> Body {
+        Body { owner: Owner { host: "some-other-machine".into(), pid: 12345 }, expires_ms }
+    }
+
+    #[test]
+    fn a_torn_owner_body_does_not_decode() {
+        let good = foreign(5_000).encode();
+        assert_eq!(Body::decode(&good), Some(foreign(5_000)));
+        for cut in 1..good.len() {
+            assert_eq!(Body::decode(&good[..cut]), None, "truncated at {cut}");
+        }
+        let text = String::from_utf8(good.clone()).unwrap();
+        let pid_flipped = text.replace("12345", "12344").into_bytes();
+        assert_eq!(Body::decode(&pid_flipped), None, "a pid off by one is not a body");
+        let expiry_flipped = text.replace("5000", "5008").into_bytes();
+        assert_eq!(Body::decode(&expiry_flipped), None);
+        assert_eq!(Body::decode(b"objkv-lease\nh\n1\n2\n"), None, "the old bare format is refused");
+    }
+
+    #[test]
+    fn the_first_process_takes_epoch_one() {
+        let s = store();
+        let c = FakeClock::at(1_000);
+        let l = Lease::acquire(&s, c).unwrap();
+        assert_eq!(l.epoch(), 1);
+        assert!(l.valid());
+        assert_eq!(l.expires_ms(), 1_000 + TTL_MS);
+        let held = current(&s).unwrap().unwrap();
+        assert_eq!((held.epoch, held.renewal), (1, 0));
+        assert_eq!(held.body.unwrap().owner, Owner::me());
+    }
+
+    #[test]
+    fn a_live_owner_on_another_host_blocks_a_claim() {
+        let s = store();
+        let c = FakeClock::at(1_000);
+        s.put_if_absent(&key(1, 0), &foreign(1_000 + TTL_MS).encode()).unwrap();
+        let err = Lease::acquire(&s, c).unwrap_err().to_string();
+        assert!(err.contains("owned by some-other-machine:12345"), "got: {err}");
+        assert!(err.contains("epoch 1"), "got: {err}");
+    }
+
+    #[test]
+    fn an_expired_owner_on_any_host_is_taken_over() {
+        let s = store();
+        let c = FakeClock::at(1_000);
+        s.put_if_absent(&key(1, 0), &foreign(1_000 + TTL_MS).encode()).unwrap();
+        s.put_if_absent(&key(1, 1), &foreign(1_000 + 2 * TTL_MS).encode()).unwrap();
+        c.set(1_000 + 2 * TTL_MS); // exactly at the expiry: still theirs
+        assert!(Lease::acquire(&s, c.clone()).is_err());
+        c.advance(1);
+        let l = Lease::acquire(&s, c).unwrap();
+        assert_eq!(l.epoch(), 2, "takeover claims the next epoch");
+        let keys = s.list("owner/").unwrap();
+        assert_eq!(keys.len(), 1, "the old claim's objects are gone: {keys:?}");
+        assert_eq!(keys[0].key, key(2, 0));
+    }
+
+    #[test]
+    fn renewal_extends_the_expiry_and_keeps_one_object() {
+        let s = store();
+        let c = FakeClock::at(1_000);
+        let l = Lease::acquire(&s, c.clone()).unwrap();
+        c.advance(HEARTBEAT_MS);
+        l.renew().unwrap();
+        assert_eq!(l.expires_ms(), 1_000 + HEARTBEAT_MS + TTL_MS);
+        let keys = s.list("owner/").unwrap();
+        assert_eq!(keys.len(), 1);
+        assert_eq!(keys[0].key, key(1, 1), "renewal 1 replaced renewal 0");
+
+        // Someone reading the bucket sees the new expiry.
+        let held = current(&s).unwrap().unwrap();
+        assert_eq!(held.body.unwrap().expires_ms, l.expires_ms());
+    }
+
+    #[test]
+    fn the_holder_stops_before_its_written_expiry() {
+        let s = store();
+        let c = FakeClock::at(1_000);
+        let l = Lease::acquire(&s, c.clone()).unwrap();
+        c.set(1_000 + TTL_MS - SKEW_MARGIN_MS - 1);
+        assert!(l.valid(), "inside the margin");
+        c.advance(1);
+        assert!(!l.valid(), "the margin is the holder's, not the claimant's");
+        let why = l.check().unwrap_err().to_string();
+        assert!(why.contains("expired"), "{why}");
+        // And it will not renew itself back into the claimants' window.
+        assert!(l.renew().is_err());
+        assert_eq!(current(&s).unwrap().unwrap().body.unwrap().expires_ms, 1_000 + TTL_MS);
+    }
+
+    #[test]
+    fn a_takeover_is_noticed_at_the_next_renewal() {
+        let s = store();
+        let c = FakeClock::at(1_000);
+        let a = Lease::acquire(&s, c.clone()).unwrap();
+        // The owner pauses past its expiry; a second process takes over.
+        c.set(1_000 + TTL_MS + 1);
+        let b = Lease::acquire(&s, c.clone()).unwrap();
+        assert_eq!(b.epoch(), 2);
+        assert!(!a.valid(), "expired on its own clock too");
+        assert!(a.renew().is_err(), "an expired lease is not renewed");
+
+        // Even a holder whose clock is behind (still thinks it is valid)
+        // learns of the takeover from the listing after its renewal.
+        c.set(1_000 + HEARTBEAT_MS);
+        let err = a.renew().unwrap_err().to_string();
+        assert!(err.contains("taken over by epoch 2"), "{err}");
+        assert!(!a.valid());
+        assert!(a.why_invalid().unwrap().contains("taken over"));
+        assert!(b.valid());
+    }
+
+    #[test]
+    fn release_expires_the_claim_so_the_next_open_claims_at_once() {
+        let s = store();
+        let c = FakeClock::at(1_000);
+        let l = Lease::acquire(&s, c.clone()).unwrap();
+        l.renew().unwrap();
+        l.release().unwrap();
+        let keys = s.list("owner/").unwrap();
+        assert_eq!(keys.len(), 1, "the claim stays, expired: {keys:?}");
+        assert_eq!(current(&s).unwrap().unwrap().body.unwrap().expires_ms, 0);
+        assert!(!l.valid());
+        assert!(l.renew().is_err());
+        assert!(l.release().is_ok(), "releasing twice is fine");
+        // The next claimant, right away, no waiting for a TTL -- and on the
+        // next epoch, never on the released one again.
+        let next = Lease::acquire(&s, c).unwrap();
+        assert_eq!(next.epoch(), 2, "epochs are never reused");
+        let keys: Vec<String> = s.list("owner/").unwrap().into_iter().map(|i| i.key).collect();
+        assert_eq!(keys, vec![key(2, 0)], "the new claim cleared the old one");
+    }
+
+    #[test]
+    fn epochs_stay_monotone_across_a_crash_a_takeover_and_a_release() {
+        // A (1) crashes; B (2) takes over after the TTL and later releases
+        // cleanly; C must be 3, or A's objects could pass for C's.
+        let s = store();
+        let c = FakeClock::at(1_000);
+        let a = Lease::acquire(&s, c.clone()).unwrap();
+        assert_eq!(a.epoch(), 1);
+        std::mem::forget(a);
+        c.set(1_000 + TTL_MS + 1);
+        let b = Lease::acquire(&s, c.clone()).unwrap();
+        assert_eq!(b.epoch(), 2);
+        b.release().unwrap();
+        let cc = Lease::acquire(&s, c).unwrap();
+        assert_eq!(cc.epoch(), 3);
+    }
+
+    #[test]
+    fn an_owner_object_that_does_not_decode_still_holds_its_epoch() {
+        let s = store();
+        s.put_if_absent(&key(3, 0), b"not a lease object").unwrap();
+        let held = current(&s).unwrap().expect("the epoch is taken");
+        assert_eq!(held.epoch, 3);
+        assert!(held.body.is_none());
+        let err = Lease::acquire(&s, FakeClock::at(1)).unwrap_err().to_string();
+        assert!(err.contains(&key(3, 0)), "must name the object: {err}");
+        assert!(!err.contains("too many"), "must not blame contention: {err}");
+    }
+
+    #[test]
+    fn a_lost_renewal_response_is_recognised_as_ours() {
+        let s = store();
+        let c = FakeClock::at(1_000);
+        let l = Lease::acquire(&s, c.clone()).unwrap();
+        // The first attempt landed but its response did not come back.
+        c.advance(100);
+        let mine = Body { owner: Owner::me(), expires_ms: c.now_ms() + TTL_MS };
+        s.put_if_absent(&key(1, 1), &mine.encode()).unwrap();
+        l.renew().unwrap();
+        assert_eq!(l.expires_ms(), mine.expires_ms);
+        assert!(l.valid());
+    }
+
+    #[test]
+    fn keys_and_bodies_round_trip() {
+        assert_eq!(parse_key(&key(7, 9)), Some((7, 9)));
+        assert_eq!(parse_key("owner/zz"), None);
+        assert_eq!(parse_key("owner/0000000000000001"), None, "the old one-level layout is not a claim");
+        let b = foreign(42);
+        assert_eq!(Body::decode(&b.encode()), Some(b));
+        assert_eq!(Body::decode(b"garbage"), None);
+    }
+}

--- a/crates/_support/objkv/src/lease.rs
+++ b/crates/_support/objkv/src/lease.rs
@@ -34,10 +34,10 @@
 //! is for: it is stamped into every commit object, and `db.rs` records a
 //! fence at each takeover so such an object is recognised and never applied.
 //! The writer closes the last gap itself: after a commit object lands and
-//! before the commit is acknowledged, `verify_in_store` asks the bucket
-//! whether `owner/<E+1>/0` exists. A takeover is exactly that key, so a
-//! writer that lost the lease -- by expiry, by a wrong clock, or by a
-//! same-host claimant that mistook it for dead -- learns so before any
+//! before the commit is acknowledged, `verify_in_store` lists the owner
+//! keys and looks for an epoch above its own. A takeover is exactly such a
+//! key, so a writer that lost the lease -- by expiry, by a wrong clock, or
+//! by a same-host claimant that mistook it for dead -- learns so before any
 //! client is told its transaction committed.
 
 use std::io;
@@ -284,9 +284,9 @@ impl Lease {
                     // A same-host owner whose pid is gone crashed: no need to
                     // wait out its lease. A pid namespace can make a live
                     // owner look gone (two containers with one hostname); the
-                    // owner is safe even then, because it asks the bucket for
-                    // `owner/<E+1>/0` after every commit object lands and
-                    // acknowledges nothing once that key exists
+                    // owner is safe even then, because it lists the owner
+                    // keys after every commit object lands and acknowledges
+                    // nothing once a newer epoch is there
                     // (`verify_in_store`). `b.owner == me` is exact: the
                     // nonce is this process's own.
                     Some(b) if now <= b.expires_ms && b.owner != me && !same_host_dead(&b.owner, &me) => {
@@ -395,14 +395,18 @@ impl Lease {
         if let Some(why) = self.why_invalid() {
             return Err(io::Error::other(format!("objkv: {why}")));
         }
-        if i.store.get(&key(i.epoch + 1, 0))?.is_some() {
-            i.lost_to.fetch_max(i.epoch + 1, Ordering::AcqRel);
-            return Err(io::Error::other(format!(
-                "objkv: the lease (epoch {}) was taken over by epoch {}; this commit is not \
-                 acknowledged and this server writes nothing more",
-                i.epoch,
-                i.epoch + 1
-            )));
+        // The listing, not a point read of `owner/<E+1>/0`: a claimant
+        // deletes the keys of the claim it replaced, so after two takeovers
+        // that one key is gone while a newer epoch owns the bucket.
+        if let Some(newest) = newest_epoch(&i.store)? {
+            if newest > i.epoch {
+                i.lost_to.fetch_max(newest, Ordering::AcqRel);
+                return Err(io::Error::other(format!(
+                    "objkv: the lease (epoch {}) was taken over by epoch {}; this commit is not \
+                     acknowledged and this server writes nothing more",
+                    i.epoch, newest
+                )));
+            }
         }
         Ok(())
     }
@@ -843,6 +847,22 @@ mod tests {
         assert!(err.contains("taken over by epoch 2"), "{err}");
         assert!(!l.valid(), "and from here on every check refuses");
         assert!(l.check().is_err());
+    }
+
+    #[test]
+    fn verify_in_store_notices_a_takeover_whose_own_claim_was_taken_over_since() {
+        let s = store();
+        let c = FakeClock::at(1_000);
+        let l = Lease::acquire(&s, c.clone()).unwrap();
+        // Epoch 2 claims, then epoch 3 claims and, as `acquire` does, deletes
+        // the keys of the claim it replaced. `owner/2/0` is gone.
+        s.put_if_absent(&key(2, 0), &foreign(c.now_ms() + TTL_MS).encode()).unwrap();
+        s.put_if_absent(&key(3, 0), &foreign(c.now_ms() + TTL_MS).encode()).unwrap();
+        s.delete(&key(2, 0)).unwrap();
+        assert!(l.valid());
+        let err = l.verify_in_store().unwrap_err().to_string();
+        assert!(err.contains("taken over by epoch 3"), "{err}");
+        assert!(!l.valid());
     }
 
     #[test]

--- a/crates/_support/objkv/src/lease.rs
+++ b/crates/_support/objkv/src/lease.rs
@@ -532,6 +532,9 @@ impl Lease {
         let handle = self.inner.heartbeat.lock().unwrap_or_else(|e| e.into_inner()).take();
         if let Some(h) = handle {
             if thread::current().id() != h.thread().id() {
+                // The thread parks between slices; the stop flag is already
+                // set, so waking it is all a prompt exit needs.
+                h.thread().unpark();
                 let _ = h.join();
             }
         }
@@ -548,14 +551,17 @@ impl Lease {
         const SLICE_MS: u64 = 250;
         // Renewals are due on a schedule, not an interval: one that took
         // long (a store retrying to its timeouts) is followed by the next as
-        // soon as it is due, not HEARTBEAT_MS later.
+        // soon as it is due, not HEARTBEAT_MS later. Between slices the
+        // thread parks, so a stop (which unparks it) is seen at once rather
+        // than at the end of a slice: a release, and every `Db` drop, waits
+        // for this thread.
         let mut due = self.inner.clock.now_ms() + HEARTBEAT_MS;
         loop {
             while self.inner.clock.now_ms() < due {
                 if self.inner.stop.load(Ordering::Acquire) {
                     return;
                 }
-                thread::sleep(std::time::Duration::from_millis(SLICE_MS));
+                thread::park_timeout(std::time::Duration::from_millis(SLICE_MS));
             }
             if self.inner.released.load(Ordering::Acquire) {
                 return;

--- a/crates/_support/objkv/src/lease.rs
+++ b/crates/_support/objkv/src/lease.rs
@@ -33,10 +33,18 @@
 //! paused past its expiry from making one more PUT. That is what the epoch
 //! is for: it is stamped into every commit object, and `db.rs` records a
 //! fence at each takeover so such an object is recognised and never applied.
+//! The writer closes the last gap itself: after a commit object lands and
+//! before the commit is acknowledged, `verify_in_store` asks the bucket
+//! whether `owner/<E+1>/0` exists. A takeover is exactly that key, so a
+//! writer that lost the lease -- by expiry, by a wrong clock, or by a
+//! same-host claimant that mistook it for dead -- learns so before any
+//! client is told its transaction committed.
 
 use std::io;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
+
+use pgsync::thread;
 
 use crate::s3::PutOutcome;
 use crate::store::Store;
@@ -60,20 +68,43 @@ pub struct SystemClock;
 
 impl Clock for SystemClock {
     fn now_ms(&self) -> u64 {
-        let since = std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH);
-        since.map_or(0, |d| d.as_millis() as u64)
+        // The workspace's wall clock: SimClock-backed under the sim harness,
+        // so a lease expiry can be replayed.
+        u64::try_from(pg_clock::wall_us() / 1_000).unwrap_or(0)
     }
 }
 
+/// Who holds a lease. The nonce is drawn once per process, so `owner == me`
+/// means this very process and nothing else: a hostname and a pid are shared
+/// by two containers with the same `hostname:` and postgres as pid 1.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Owner {
     pub host: String,
     pub pid: u32,
+    pub nonce: u64,
 }
 
 impl Owner {
     pub fn me() -> Owner {
-        Owner { host: hostname(), pid: std::process::id() }
+        static NONCE: OnceLock<u64> = OnceLock::new();
+        let nonce = *NONCE.get_or_init(|| {
+            // Time, pid and a stack address, mixed: not a secret, only
+            // something two processes will not both draw.
+            let t = pg_clock::wall_ns() as u64;
+            let stack = 0u8;
+            let a = &stack as *const u8 as u64;
+            let mut x = t ^ (u64::from(std::process::id()) << 32) ^ a.rotate_left(17);
+            x ^= x >> 33;
+            x = x.wrapping_mul(0xff51_afd7_ed55_8ccd);
+            x ^= x >> 33;
+            x | 1
+        });
+        Owner { host: hostname(), pid: std::process::id(), nonce }
+    }
+
+    /// Same host and pid, whoever that is now.
+    fn same_host_pid(&self, other: &Owner) -> bool {
+        self.host == other.host && self.pid == other.pid
     }
 }
 
@@ -90,8 +121,11 @@ impl Body {
     /// looks dead, or a dead one that looks alive for ever, and either is a
     /// second writer. Unreadable, it is left to the operator instead.
     pub fn encode(&self) -> Vec<u8> {
-        let text = format!("objkv-lease\n{}\n{}\n{}\n", self.owner.host, self.owner.pid, self.expires_ms);
-        let crc = crc32c::pg_comp_crc32c(0xffff_ffff, text.as_bytes()) ^ 0xffff_ffff;
+        let text = format!(
+            "objkv-lease\n{}\n{}\n{:016x}\n{}\n",
+            self.owner.host, self.owner.pid, self.owner.nonce, self.expires_ms
+        );
+        let crc = crate::crc(text.as_bytes());
         format!("{text}crc:{crc:08x}\n").into_bytes()
     }
     fn decode(b: &[u8]) -> Option<Body> {
@@ -99,7 +133,7 @@ impl Body {
         let (text, crc_line) = s.strip_suffix('\n')?.rsplit_once('\n')?;
         let want = u32::from_str_radix(crc_line.strip_prefix("crc:")?, 16).ok()?;
         let text = format!("{text}\n");
-        if crc32c::pg_comp_crc32c(0xffff_ffff, text.as_bytes()) ^ 0xffff_ffff != want {
+        if crate::crc(text.as_bytes()) != want {
             return None;
         }
         let mut it = text.lines();
@@ -107,7 +141,11 @@ impl Body {
             return None;
         }
         let body = Body {
-            owner: Owner { host: it.next()?.to_string(), pid: it.next()?.parse().ok()? },
+            owner: Owner {
+                host: it.next()?.to_string(),
+                pid: it.next()?.parse().ok()?,
+                nonce: u64::from_str_radix(it.next()?, 16).ok()?,
+            },
             expires_ms: it.next()?.parse().ok()?,
         };
         it.next().is_none().then_some(body)
@@ -145,16 +183,34 @@ pub struct Held {
 /// fail separately: an owner object that does not decode still proves its
 /// epoch is taken.
 pub fn current(store: &Arc<dyn Store>) -> io::Result<Option<Held>> {
-    let keys: Vec<String> = store.list("owner/")?.into_iter().map(|i| i.key).collect();
-    let Some((epoch, renewal, k)) = keys
-        .iter()
-        .filter_map(|k| parse_key(k).map(|(e, n)| (e, n, k.clone())))
-        .max()
-    else {
-        return Ok(None);
-    };
-    let body = store.get(&k)?.and_then(|b| Body::decode(&b));
-    Ok(Some(Held { epoch, renewal, key: k, body, keys }))
+    // The listing and the read are two round trips, and a live holder renews
+    // between them: its newest key is deleted just after it was listed. That
+    // is a healthy owner, not an unreadable one, so the listing is taken
+    // again. Only an object that is there and does not decode is reported as
+    // unreadable.
+    for _ in 0..8 {
+        let keys: Vec<String> = store.list("owner/")?.into_iter().map(|i| i.key).collect();
+        let Some((epoch, renewal, k)) = keys
+            .iter()
+            .filter_map(|k| parse_key(k).map(|(e, n)| (e, n, k.clone())))
+            .max()
+        else {
+            return Ok(None);
+        };
+        match store.get(&k)? {
+            Some(b) => return Ok(Some(Held { epoch, renewal, key: k, body: Body::decode(&b), keys })),
+            None => continue,
+        }
+    }
+    Err(io::Error::other(
+        "objkv: the newest owner object keeps disappearing between the listing and the read",
+    ))
+}
+
+/// The newest epoch anything has claimed, from the listing alone: what the
+/// holder's takeover check needs, without the read `current` adds.
+fn newest_epoch(store: &Arc<dyn Store>) -> io::Result<Option<u64>> {
+    Ok(store.list("owner/")?.into_iter().filter_map(|i| parse_key(&i.key).map(|(e, _)| e)).max())
 }
 
 struct Inner {
@@ -170,6 +226,9 @@ struct Inner {
     released: AtomicBool,
     /// Tells the heartbeat thread to stop.
     stop: AtomicBool,
+    /// The heartbeat thread, so a release can wait for a renewal in flight
+    /// instead of racing it for the next renewal number.
+    heartbeat: pgsync::Mutex<Option<thread::JoinHandle<()>>>,
 }
 
 /// A held lease. Cloning shares it; the heartbeat thread holds one clone.
@@ -194,10 +253,11 @@ impl Lease {
     pub fn acquire_with_heartbeat(store: &Arc<dyn Store>) -> io::Result<Lease> {
         let lease = Lease::acquire(store, Arc::new(SystemClock))?;
         let beat = lease.clone();
-        std::thread::Builder::new()
+        let handle = thread::Builder::new()
             .name("objkv-lease".into())
             .spawn(move || beat.heartbeat())
             .map_err(|e| io::Error::other(format!("objkv: cannot start the lease heartbeat: {e}")))?;
+        *lease.inner.heartbeat.lock().unwrap_or_else(|e| e.into_inner()) = Some(handle);
         Ok(lease)
     }
 
@@ -215,21 +275,25 @@ impl Lease {
                     // expired: a live server and a corrupt object look the same.
                     None => {
                         return Err(io::Error::other(format!(
-                            "this bucket is owned by a lease this version cannot read \\
-                             (`{}`). If that server is definitely gone, delete the object \\
+                            "this bucket is owned by a lease this version cannot read \
+                             (`{}`). If that server is definitely gone, delete the object \
                              and start again.",
                             h.key
                         )))
                     }
                     // A same-host owner whose pid is gone crashed: no need to
-                    // wait out its lease. (A pid namespace can make a live
-                    // owner look gone; the epoch check on every PUT is the
-                    // defence for that case.)
+                    // wait out its lease. A pid namespace can make a live
+                    // owner look gone (two containers with one hostname); the
+                    // owner is safe even then, because it asks the bucket for
+                    // `owner/<E+1>/0` after every commit object lands and
+                    // acknowledges nothing once that key exists
+                    // (`verify_in_store`). `b.owner == me` is exact: the
+                    // nonce is this process's own.
                     Some(b) if now <= b.expires_ms && b.owner != me && !same_host_dead(&b.owner, &me) => {
                         return Err(io::Error::other(format!(
-                            "this bucket is owned by {}:{} (lease epoch {}, valid for another \\
-                             {} ms). Two servers sharing one bucket would overwrite each \\
-                             other's rows. A server that stops renewing is taken over \\
+                            "this bucket is owned by {}:{} (lease epoch {}, valid for another \
+                             {} ms). Two servers sharing one bucket would overwrite each \
+                             other's rows. A server that stops renewing is taken over \
                              automatically once its lease expires.",
                             b.owner.host,
                             b.owner.pid,
@@ -263,6 +327,7 @@ impl Lease {
                         lost_to: AtomicU64::new(0),
                         released: AtomicBool::new(false),
                         stop: AtomicBool::new(false),
+                        heartbeat: pgsync::Mutex::new(None),
                     }),
                 });
             }
@@ -293,7 +358,7 @@ impl Lease {
         let lost = i.lost_to.load(Ordering::Acquire);
         if lost != 0 {
             return Some(format!(
-                "the lease (epoch {}) was taken over by epoch {lost}; another server owns \\
+                "the lease (epoch {}) was taken over by epoch {lost}; another server owns \
                  the bucket now",
                 i.epoch
             ));
@@ -302,7 +367,7 @@ impl Lease {
         let expires = i.expires_ms.load(Ordering::Acquire);
         if now + SKEW_MARGIN_MS >= expires {
             return Some(format!(
-                "the lease (epoch {}) expired: last renewed to {expires} ms, now {now} ms; \\
+                "the lease (epoch {}) expired: last renewed to {expires} ms, now {now} ms; \
                  another server may own the bucket",
                 i.epoch
             ));
@@ -316,6 +381,30 @@ impl Lease {
             Some(why) => Err(io::Error::other(format!("objkv: {why}"))),
             None => Ok(()),
         }
+    }
+
+    /// The bucket's answer to "is this lease still the newest?": one point
+    /// read of the key a takeover would have created. Meant for the writer,
+    /// after a commit object lands and before the commit is acknowledged, so
+    /// that a lease lost by any route -- expiry, a wrong clock, a same-host
+    /// claimant that took a live owner for dead -- is found before a client
+    /// is told anything. A lost lease is recorded, and every later `check`
+    /// refuses.
+    pub fn verify_in_store(&self) -> io::Result<()> {
+        let i = &self.inner;
+        if let Some(why) = self.why_invalid() {
+            return Err(io::Error::other(format!("objkv: {why}")));
+        }
+        if i.store.get(&key(i.epoch + 1, 0))?.is_some() {
+            i.lost_to.fetch_max(i.epoch + 1, Ordering::AcqRel);
+            return Err(io::Error::other(format!(
+                "objkv: the lease (epoch {}) was taken over by epoch {}; this commit is not \
+                 acknowledged and this server writes nothing more",
+                i.epoch,
+                i.epoch + 1
+            )));
+        }
+        Ok(())
     }
 
     /// Writes the next renewal, then looks for a takeover. Either failure
@@ -336,19 +425,14 @@ impl Lease {
         let n = i.renewal.load(Ordering::Acquire) + 1;
         let expires_ms = now + TTL_MS;
         let body = Body { owner: i.me.clone(), expires_ms };
-        match i.store.put_if_absent(&key(i.epoch, n), &body.encode())? {
-            PutOutcome::Written => {}
+        let landed = match i.store.put_if_absent(&key(i.epoch, n), &body.encode())? {
+            PutOutcome::Written => expires_ms,
             // Only this process writes under its epoch, so an existing
             // object is our own, from an attempt whose response was lost.
             PutOutcome::AlreadyExists => {
                 let found = i.store.get(&key(i.epoch, n))?.and_then(|b| Body::decode(&b));
                 match found {
-                    Some(b) if b.owner == i.me => {
-                        i.expires_ms.fetch_max(b.expires_ms, Ordering::AcqRel);
-                        i.renewal.store(n, Ordering::Release);
-                        let _ = i.store.delete(&key(i.epoch, n - 1));
-                        return self.check_takeover();
-                    }
+                    Some(b) if b.owner == i.me => b.expires_ms,
                     _ => {
                         return Err(io::Error::other(format!(
                             "objkv: renewal object `{}` exists and is not ours",
@@ -357,21 +441,26 @@ impl Lease {
                     }
                 }
             }
-        }
-        i.expires_ms.fetch_max(expires_ms, Ordering::AcqRel);
+        };
         i.renewal.store(n, Ordering::Release);
+        // The takeover check comes before the expiry is believed: a renewal
+        // that landed beside a newer epoch's claim renewed nothing.
+        self.check_takeover()?;
+        i.expires_ms.fetch_max(landed, Ordering::AcqRel);
+        // Best effort, and last: the renewal is done whether or not the
+        // previous object goes; a leftover is one more key in a listing.
         let _ = i.store.delete(&key(i.epoch, n - 1));
-        self.check_takeover()
+        Ok(())
     }
 
     fn check_takeover(&self) -> io::Result<()> {
         let i = &self.inner;
-        if let Some(h) = current(&i.store)? {
-            if h.epoch > i.epoch {
-                i.lost_to.fetch_max(h.epoch, Ordering::AcqRel);
+        if let Some(epoch) = newest_epoch(&i.store)? {
+            if epoch > i.epoch {
+                i.lost_to.fetch_max(epoch, Ordering::AcqRel);
                 return Err(io::Error::other(format!(
                     "objkv: the lease (epoch {}) was taken over by epoch {}",
-                    i.epoch, h.epoch
+                    i.epoch, epoch
                 )));
             }
         }
@@ -384,59 +473,108 @@ impl Lease {
     /// The claim is expired, not deleted: a renewal whose expiry is already
     /// past goes in as the newest object under this epoch, so the epoch
     /// stays visible (and is never handed out again) until the next claim
-    /// supersedes it. A renewal already on the wire when this runs can land
-    /// after it, which costs the next open a wait of at most the TTL; the
-    /// heartbeat checks `released` before each renewal, so that needs the
-    /// two to cross within one round trip.
+    /// supersedes it. The heartbeat is stopped and waited for first, so no
+    /// renewal is on the wire when the number is chosen; a renewal whose
+    /// response was lost earlier can still occupy it, and then the release
+    /// goes in under the next number.
     pub fn release(&self) -> io::Result<()> {
         let i = &self.inner;
         i.stop.store(true, Ordering::Release);
+        self.join_heartbeat();
         if i.released.swap(true, Ordering::AcqRel) {
             return Ok(());
         }
         if i.lost_to.load(Ordering::Acquire) != 0 {
             return Ok(()); // the next epoch's claim has superseded ours already
         }
-        let n = i.renewal.load(Ordering::Acquire) + 1;
         let body = Body { owner: i.me.clone(), expires_ms: 0 };
-        // The previous object goes only once the new one is known to be
-        // there: a store that reports "exists" for an object it does not hold
-        // would otherwise leave this epoch with no object at all, and the
-        // next claimant counting on from whatever older leftover it lists.
-        if i.store.put_if_absent(&key(i.epoch, n), &body.encode())? == PutOutcome::AlreadyExists
-            && i.store.get(&key(i.epoch, n))?.is_none()
-        {
-            return Err(io::Error::other(format!(
-                "objkv: release: `{}` was reported to exist but is not there; the claim is left to expire",
-                key(i.epoch, n)
-            )));
+        let mut n = i.renewal.load(Ordering::Acquire) + 1;
+        for _ in 0..4 {
+            let k = key(i.epoch, n);
+            match i.store.put_if_absent(&k, &body.encode())? {
+                PutOutcome::Written => {}
+                // The previous object goes only once the new one is known to
+                // be there: a store that reports "exists" for an object it
+                // does not hold would otherwise leave this epoch with no
+                // object at all, and the next claimant counting on from
+                // whatever older leftover it lists.
+                PutOutcome::AlreadyExists => match i.store.get(&k)?.and_then(|b| Body::decode(&b)) {
+                    None => {
+                        return Err(io::Error::other(format!(
+                            "objkv: release: `{k}` was reported to exist but is not there or does \
+                             not read; the claim is left to expire"
+                        )))
+                    }
+                    // A renewal of ours whose response was lost: it is live,
+                    // so the release must be the newer object.
+                    Some(b) if b.expires_ms != 0 => {
+                        n += 1;
+                        continue;
+                    }
+                    Some(_) => {}
+                },
+            }
+            i.renewal.store(n, Ordering::Release);
+            i.expires_ms.store(0, Ordering::Release);
+            // Every older object under this epoch: the release is the newest
+            // and the only one that matters.
+            for old in i.store.list(&format!("owner/{:016x}/", i.epoch))? {
+                if old.key != k {
+                    let _ = i.store.delete(&old.key);
+                }
+            }
+            return Ok(());
         }
-        i.renewal.store(n, Ordering::Release);
-        i.expires_ms.store(0, Ordering::Release);
-        i.store.delete(&key(i.epoch, n - 1))
+        Err(io::Error::other("objkv: release: could not find a free renewal number"))
+    }
+
+    fn join_heartbeat(&self) {
+        let handle = self.inner.heartbeat.lock().unwrap_or_else(|e| e.into_inner()).take();
+        if let Some(h) = handle {
+            if thread::current().id() != h.thread().id() {
+                let _ = h.join();
+            }
+        }
     }
 
     /// Stops the heartbeat without releasing: for a process that has been
     /// fenced and must not touch the bucket again.
     pub fn stop_heartbeat(&self) {
         self.inner.stop.store(true, Ordering::Release);
+        self.join_heartbeat();
     }
 
     fn heartbeat(self) {
         const SLICE_MS: u64 = 250;
+        // Renewals are due on a schedule, not an interval: one that took
+        // long (a store retrying to its timeouts) is followed by the next as
+        // soon as it is due, not HEARTBEAT_MS later.
+        let mut due = self.inner.clock.now_ms() + HEARTBEAT_MS;
         loop {
-            for _ in 0..HEARTBEAT_MS / SLICE_MS {
+            while self.inner.clock.now_ms() < due {
                 if self.inner.stop.load(Ordering::Acquire) {
                     return;
                 }
-                std::thread::sleep(std::time::Duration::from_millis(SLICE_MS));
+                thread::sleep(std::time::Duration::from_millis(SLICE_MS));
             }
             if self.inner.released.load(Ordering::Acquire) {
                 return;
             }
+            due = self.inner.clock.now_ms() + HEARTBEAT_MS;
             if let Err(e) = self.renew() {
                 eprintln!("objkv lease: renewal failed: {e}");
                 if self.inner.lost_to.load(Ordering::Acquire) != 0 {
+                    return;
+                }
+                // An expiry does not come back: `renew` refuses to write into
+                // the claimants' window. Every write is refused from here on
+                // (`check`), and the server needs a restart to claim again.
+                if self.why_invalid().is_some() {
+                    eprintln!(
+                        "objkv lease: epoch {} is over; this server writes nothing more until \
+                         it is restarted",
+                        self.inner.epoch
+                    );
                     return;
                 }
             }
@@ -446,7 +584,7 @@ impl Lease {
 
 /// True when `owner` is a process on this host that no longer exists.
 fn same_host_dead(owner: &Owner, me: &Owner) -> bool {
-    if owner.host != me.host || owner.pid == 0 {
+    if owner.host != me.host || owner.pid == 0 || owner.same_host_pid(me) {
         return false;
     }
     let rc = unsafe { libc::kill(owner.pid as libc::pid_t, 0) };
@@ -504,7 +642,7 @@ mod tests {
     }
 
     fn foreign(expires_ms: u64) -> Body {
-        Body { owner: Owner { host: "some-other-machine".into(), pid: 12345 }, expires_ms }
+        Body { owner: Owner { host: "some-other-machine".into(), pid: 12345, nonce: 7 }, expires_ms }
     }
 
     #[test]
@@ -520,6 +658,11 @@ mod tests {
         let expiry_flipped = text.replace("5000", "5008").into_bytes();
         assert_eq!(Body::decode(&expiry_flipped), None);
         assert_eq!(Body::decode(b"objkv-lease\nh\n1\n2\n"), None, "the old bare format is refused");
+        assert_eq!(
+            Body::decode(b"objkv-lease\nh\n1\n2\ncrc:00000000\n"),
+            None,
+            "a body without the nonce line is refused"
+        );
     }
 
     #[test]
@@ -678,6 +821,98 @@ mod tests {
         l.renew().unwrap();
         assert_eq!(l.expires_ms(), mine.expires_ms);
         assert!(l.valid());
+    }
+
+    #[test]
+    fn verify_in_store_notices_a_takeover_claim_before_anything_is_acknowledged() {
+        let s = store();
+        let c = FakeClock::at(1_000);
+        let l = Lease::acquire(&s, c.clone()).unwrap();
+        l.verify_in_store().unwrap();
+        // A claimant that took this live owner for dead (same hostname,
+        // another pid namespace) claims the next epoch.
+        s.put_if_absent(&key(2, 0), &foreign(c.now_ms() + TTL_MS).encode()).unwrap();
+        assert!(l.valid(), "the clock alone says nothing is wrong");
+        let err = l.verify_in_store().unwrap_err().to_string();
+        assert!(err.contains("taken over by epoch 2"), "{err}");
+        assert!(!l.valid(), "and from here on every check refuses");
+        assert!(l.check().is_err());
+    }
+
+    #[test]
+    fn release_after_a_lost_renewal_response_goes_in_under_the_next_number() {
+        let s = store();
+        let c = FakeClock::at(1_000);
+        let l = Lease::acquire(&s, c.clone()).unwrap();
+        // A renewal landed at n = 1 but its response was lost, so the lease
+        // still counts itself at n = 0.
+        let live = Body { owner: Owner::me(), expires_ms: c.now_ms() + TTL_MS };
+        s.put_if_absent(&key(1, 1), &live.encode()).unwrap();
+        l.release().unwrap();
+        let held = current(&s).unwrap().unwrap();
+        assert_eq!((held.epoch, held.renewal), (1, 2), "the release is the newest object");
+        assert_eq!(held.body.unwrap().expires_ms, 0, "and it is expired");
+        assert!(s.get(&key(1, 1)).unwrap().is_none(), "the live renewal is gone");
+        // The next claimant does not wait.
+        let next = Lease::acquire(&s, c).unwrap();
+        assert_eq!(next.epoch(), 2);
+    }
+
+    #[test]
+    fn a_live_owner_with_this_host_and_pid_but_another_nonce_is_another_process() {
+        let s = store();
+        let c = FakeClock::at(1_000);
+        let me = Owner::me();
+        let twin = Owner { host: me.host.clone(), pid: me.pid, nonce: me.nonce ^ 1 };
+        let body = Body { owner: twin, expires_ms: c.now_ms() + TTL_MS };
+        s.put_if_absent(&key(1, 0), &body.encode()).unwrap();
+        let err = Lease::acquire(&s, c).unwrap_err().to_string();
+        assert!(err.contains("owned by"), "a container with our hostname and pid is not us: {err}");
+    }
+
+    /// Lists a key that is gone by the time it is read, once: the holder
+    /// renewed between the listing and the read.
+    struct VanishesOnce {
+        inner: Arc<dyn Store>,
+        armed: std::sync::atomic::AtomicBool,
+    }
+
+    impl Store for VanishesOnce {
+        fn put_if_absent(&self, key: &str, body: &[u8]) -> io::Result<PutOutcome> {
+            self.inner.put_if_absent(key, body)
+        }
+        fn get(&self, key: &str) -> io::Result<Option<Vec<u8>>> {
+            self.inner.get(key)
+        }
+        fn get_range(&self, key: &str, offset: u64, len: u64) -> io::Result<Option<Vec<u8>>> {
+            self.inner.get_range(key, offset, len)
+        }
+        fn list(&self, prefix: &str) -> io::Result<Vec<crate::s3::ObjectInfo>> {
+            let mut all = self.inner.list(prefix)?;
+            if self.armed.swap(false, Ordering::SeqCst) {
+                all.push(crate::s3::ObjectInfo { key: key(1, 9), size: 0 });
+            }
+            Ok(all)
+        }
+        fn delete(&self, key: &str) -> io::Result<()> {
+            self.inner.delete(key)
+        }
+    }
+
+    #[test]
+    fn a_key_that_vanishes_between_the_listing_and_the_read_is_listed_again() {
+        let inner = store();
+        let c = FakeClock::at(1_000);
+        let s: Arc<dyn Store> = Arc::new(VanishesOnce {
+            inner: Arc::clone(&inner),
+            armed: std::sync::atomic::AtomicBool::new(true),
+        });
+        let held = Lease::acquire(&inner, c.clone()).unwrap();
+        // The stale listing names owner/1/9, which no longer exists.
+        let seen = current(&s).unwrap().unwrap();
+        assert_eq!((seen.epoch, seen.renewal), (1, 0), "the real newest object, not an error");
+        assert!(seen.body.is_some());
+        drop(held);
     }
 
     #[test]

--- a/crates/_support/objkv/src/lib.rs
+++ b/crates/_support/objkv/src/lib.rs
@@ -1,0 +1,16 @@
+//! An LSM key/value store over an object store, with no write-ahead log: a
+//! transaction is one immutable object, and their sequence is the log.
+//!
+//! This crate lands in two steps. The object-store client, the run format,
+//! the key encodings, the lease and the fault-injection hooks are here; the
+//! database engine over them (`db`, `index`) follows in the next change.
+
+pub mod bloom;
+pub mod index_key;
+pub mod key;
+pub mod lease;
+pub mod faults;
+pub mod commit;
+pub mod run;
+pub mod s3;
+pub mod store;

--- a/crates/_support/objkv/src/lib.rs
+++ b/crates/_support/objkv/src/lib.rs
@@ -5,6 +5,12 @@
 //! the key encodings, the lease and the fault-injection hooks are here; the
 //! database engine over them (`db`, `index`) follows in the next change.
 
+/// The on-bucket checksum: CRC-32C with the workspace's init and finalise,
+/// one definition for every object kind this crate writes.
+pub(crate) fn crc(bytes: &[u8]) -> u32 {
+    crc32c::fin_crc32c(crc32c::pg_comp_crc32c(crc32c::CRC32C_INIT, bytes))
+}
+
 pub mod bloom;
 pub mod index_key;
 pub mod key;

--- a/crates/_support/objkv/src/run.rs
+++ b/crates/_support/objkv/src/run.rs
@@ -1,0 +1,1006 @@
+//! Sorted runs: `run/<id>`, written by compaction, read by ranged GET.
+//!
+//! Layout — bloom and index are adjacent on purpose, so opening a run costs two
+//! ranged GETs (trailer, then bloom+index together) and every subsequent point
+//! read costs at most one more:
+//!
+//! ```text
+//! [block 0][block 1]...[bloom][index][trailer]
+//! ```
+//!
+//! A block is ~64KB of sorted entries followed by a CRC32C of them. The index
+//! holds each block's first key, so a lookup binary-searches in memory and
+//! fetches exactly one block.
+//!
+//! Every byte a reader trusts is covered by a checksum: the blocks by their
+//! own, the bloom and index by `meta_crc`, the trailer fields by
+//! `trailer_crc`. A run arrives over the network like a commit object does,
+//! and a flipped bit served as a missing row is a wrong answer; verified, it
+//! is an error instead.
+//!
+//! A run also records the collection horizon it was built with: history at
+//! or below it was dropped from the run, so a read below it cannot be
+//! answered from the run and is refused. Carried here rather than in a
+//! marker object of its own so that it cannot fail to land separately from
+//! the run whose history it describes.
+
+use std::collections::HashMap;
+use std::io;
+use std::sync::Mutex;
+
+use crate::bloom::Bloom;
+use crate::commit::{get_u32, get_u64, put_u32, put_u64, Op};
+use crate::key;
+
+/// Format 3: blocks carry a CRC32C each, the trailer carries its own and the
+/// collection horizon. Format 2 runs are refused by name; none were ever
+/// written outside tests, so there is nothing to migrate.
+pub const MAGIC: u32 = 0x4f4b_5233; // "OKR3"
+const MAGIC_V2: u32 = 0x4f4b_5232; // "OKR2"
+/// bloom_off u64, bloom_len u32, index_off u64, index_len u32, block_count
+/// u32, entry_count u64, horizon u64, meta_crc u32, trailer_crc u32, magic u32.
+pub const TRAILER_LEN: u64 = 56;
+/// The bytes of the trailer `trailer_crc` covers: everything before it.
+const TRAILER_CRC_AT: usize = 48;
+/// Every block ends in a CRC32C of the bytes before it.
+const BLOCK_CRC_LEN: usize = 4;
+pub const TARGET_BLOCK_BYTES: usize = 64 * 1024;
+/// Default local block cache. Stands in for the NVMe cache a real deployment
+/// would keep; without it every point read is a network round trip and the
+/// warm-read threshold is unmeasurable.
+pub const DEFAULT_CACHE_BYTES: usize = 64 * 1024 * 1024;
+
+pub fn key_for(id: u64) -> String {
+    format!("run/{id:016x}")
+}
+
+/// A delta run holds only the commits since the run before it, where a run
+/// without the suffix holds everything up to its number.
+pub const DELTA_SUFFIX: &str = ".d";
+
+pub fn delta_key_for(id: u64) -> String {
+    format!("run/{id:016x}{DELTA_SUFFIX}")
+}
+
+pub fn is_delta(key: &str) -> bool {
+    key.ends_with(DELTA_SUFFIX)
+}
+
+/// A run is live once its seal exists: `sealed/<id>[.d]`, written by the
+/// compactor after the run has been read back byte for byte. A run without
+/// one is a fold that did not finish -- the PUT failed to be verified, or
+/// the process died between the two -- and the next open deletes it. So a
+/// torn upload never becomes the run a restart reads.
+pub const SEAL_PREFIX: &str = "sealed/";
+
+pub fn seal_key_for(run_key: &str) -> String {
+    format!("{SEAL_PREFIX}{}", run_key.strip_prefix("run/").unwrap_or(run_key))
+}
+
+/// `sealed/<id>` -> `run/<id>`.
+pub fn run_key_of_seal(seal_key: &str) -> Option<String> {
+    seal_key.strip_prefix(SEAL_PREFIX).map(|tail| format!("run/{tail}"))
+}
+
+fn crc(bytes: &[u8]) -> u32 {
+    crc32c::pg_comp_crc32c(0xffff_ffff, bytes) ^ 0xffff_ffff
+}
+
+/// Anything a run can be read from: an S3 object, or a byte slice in tests.
+pub trait RangeSource {
+    fn range(&self, offset: u64, len: u64) -> io::Result<Vec<u8>>;
+    fn size(&self) -> u64;
+}
+
+impl RangeSource for &[u8] {
+    fn range(&self, offset: u64, len: u64) -> io::Result<Vec<u8>> {
+        let past = || io::Error::other("range past end of object");
+        let s = usize::try_from(offset).map_err(|_| past())?;
+        let e = offset.checked_add(len).and_then(|e| usize::try_from(e).ok()).ok_or_else(past)?;
+        if e > self.len() {
+            return Err(past());
+        }
+        Ok(self[s..e].to_vec())
+    }
+    fn size(&self) -> u64 {
+        self.len() as u64
+    }
+}
+
+/// Serialise sorted `(key, op)` pairs into a run object built with the given
+/// collection horizon (0 for none; see the module doc).
+///
+/// Entries must already be sorted by key and deduplicated; compaction owns
+/// that, not this function.
+pub fn build(entries: &[(Vec<u8>, Op)], horizon: u64) -> Vec<u8> {
+    let mut out = Vec::new();
+    let mut index: Vec<(Vec<u8>, u64, u32)> = Vec::new();
+
+    let mut i = 0usize;
+    while i < entries.len() {
+        let block_off = out.len() as u64;
+        let first_key = entries[i].0.clone();
+        let start = out.len();
+        while i < entries.len() && out.len() - start < TARGET_BLOCK_BYTES {
+            let (k, op) = &entries[i];
+            put_u32(&mut out, k.len() as u32);
+            out.extend_from_slice(k);
+            match op {
+                Op::Put(v) => {
+                    out.push(0);
+                    put_u32(&mut out, v.len() as u32);
+                    out.extend_from_slice(v);
+                }
+                Op::Delete => {
+                    out.push(1);
+                    put_u32(&mut out, 0);
+                }
+            }
+            i += 1;
+        }
+        let block_crc = crc(&out[start..]);
+        put_u32(&mut out, block_crc);
+        index.push((first_key, block_off, (out.len() - start) as u32));
+    }
+
+    // Bloom over row keys: a seek knows the row, not the version.
+    let keys: Vec<&[u8]> = entries
+        .iter()
+        .map(|(k, _)| key::row_of(k).unwrap_or(k.as_slice()))
+        .collect();
+    let bloom = Bloom::build(&keys);
+    let bloom_off = out.len() as u64;
+    out.extend_from_slice(bloom.as_bytes());
+    let bloom_len = (out.len() as u64 - bloom_off) as u32;
+
+    let index_off = out.len() as u64;
+    for (k, off, len) in &index {
+        put_u32(&mut out, k.len() as u32);
+        out.extend_from_slice(k);
+        put_u64(&mut out, *off);
+        put_u32(&mut out, *len);
+    }
+    let index_len = (out.len() as u64 - index_off) as u32;
+
+    let meta_crc = crc(&out[bloom_off as usize..(index_off + index_len as u64) as usize]);
+
+    let trailer_at = out.len();
+    put_u64(&mut out, bloom_off);
+    put_u32(&mut out, bloom_len);
+    put_u64(&mut out, index_off);
+    put_u32(&mut out, index_len);
+    put_u32(&mut out, index.len() as u32);
+    put_u64(&mut out, entries.len() as u64);
+    put_u64(&mut out, horizon);
+    put_u32(&mut out, meta_crc);
+    debug_assert_eq!(out.len() - trailer_at, TRAILER_CRC_AT);
+    let trailer_crc = crc(&out[trailer_at..]);
+    put_u32(&mut out, trailer_crc);
+    put_u32(&mut out, MAGIC);
+    debug_assert_eq!(out.len() - trailer_at, TRAILER_LEN as usize);
+    out
+}
+
+/// An opened run: bloom and index held locally, blocks fetched on demand.
+pub struct Run<S: RangeSource> {
+    src: S,
+    bloom: Bloom,
+    /// (first_key, block_offset, block_len), ascending by first_key.
+    index: Vec<(Vec<u8>, u64, u32)>,
+    pub entry_count: u64,
+    /// History at or below this was dropped when the run was built.
+    pub horizon: u64,
+    cache: Mutex<BlockCache>,
+}
+
+/// FIFO block cache. Not an LRU — the access pattern under test is uniform
+/// random, where the two behave the same and FIFO is simpler to reason about.
+#[derive(Default)]
+struct BlockCache {
+    blocks: HashMap<u64, Vec<u8>>,
+    order: std::collections::VecDeque<u64>,
+    bytes: usize,
+    cap: usize,
+    pub hits: u64,
+    pub misses: u64,
+}
+
+impl BlockCache {
+    fn get(&mut self, off: u64) -> Option<Vec<u8>> {
+        match self.blocks.get(&off) {
+            Some(b) => {
+                self.hits += 1;
+                Some(b.clone())
+            }
+            None => {
+                self.misses += 1;
+                None
+            }
+        }
+    }
+    fn insert(&mut self, off: u64, block: Vec<u8>) {
+        if self.cap == 0 || block.len() > self.cap {
+            return;
+        }
+        while self.bytes + block.len() > self.cap {
+            let Some(old) = self.order.pop_front() else { break };
+            if let Some(b) = self.blocks.remove(&old) {
+                self.bytes -= b.len();
+            }
+        }
+        self.bytes += block.len();
+        self.order.push_back(off);
+        self.blocks.insert(off, block);
+    }
+}
+
+/// The bloom and index of a run, parsed from wherever its bytes are.
+struct Meta {
+    bloom: Bloom,
+    index: Vec<(Vec<u8>, u64, u32)>,
+    entry_count: u64,
+    horizon: u64,
+}
+
+/// Two ranged reads of `src`: the trailer, then bloom and index in one call.
+fn read_meta<S: RangeSource>(src: &S) -> io::Result<Meta> {
+    let size = src.size();
+    if size < TRAILER_LEN {
+        return Err(io::Error::other("object too small to be a run"));
+    }
+    let t = src.range(size - TRAILER_LEN, TRAILER_LEN)?;
+    if t.len() != TRAILER_LEN as usize {
+        return Err(io::Error::other("short read of the run trailer"));
+    }
+    match get_u32(&t, 52) {
+        MAGIC => {}
+        MAGIC_V2 => {
+            return Err(io::Error::other(
+                "run is in format 2 (OKR2), which this objkv does not read: it reads format 3 \
+                 only, whose blocks and trailer carry checksums. A bucket written by an older \
+                 objkv must be migrated, not opened",
+            ))
+        }
+        _ => return Err(io::Error::other("bad run magic")),
+    }
+    if get_u32(&t, TRAILER_CRC_AT) != crc(&t[..TRAILER_CRC_AT]) {
+        return Err(io::Error::other("run trailer checksum mismatch"));
+    }
+    let bloom_off = get_u64(&t, 0);
+    let bloom_len = get_u32(&t, 8) as u64;
+    let index_off = get_u64(&t, 12);
+    let index_len = get_u32(&t, 20) as u64;
+    let block_count = get_u32(&t, 24) as usize;
+    let entry_count = get_u64(&t, 28);
+    let horizon = get_u64(&t, 36);
+    let want_crc = get_u32(&t, 44);
+    // The single bloom+index fetch below depends on them being adjacent.
+    if bloom_off.checked_add(bloom_len) != Some(index_off)
+        || index_off.checked_add(index_len).is_none_or(|end| end > size - TRAILER_LEN)
+    {
+        return Err(io::Error::other("run metadata is not contiguous"));
+    }
+
+    let meta = src.range(bloom_off, bloom_len + index_len)?;
+    if meta.len() as u64 != bloom_len + index_len {
+        return Err(io::Error::other("short read of the run metadata"));
+    }
+    if want_crc != crc(&meta) {
+        return Err(io::Error::other("run metadata checksum mismatch"));
+    }
+
+    let bloom = Bloom::from_bytes(meta[..bloom_len as usize].to_vec());
+    let ibytes = &meta[bloom_len as usize..];
+    let mut index = Vec::new();
+    let mut p = 0usize;
+    let short = || io::Error::other("run index is truncated");
+    while p < ibytes.len() {
+        let klen = crate::commit::get_u32_checked(ibytes, p).ok_or_else(short)? as usize;
+        p += 4;
+        let key = ibytes.get(p..p.checked_add(klen).ok_or_else(short)?).ok_or_else(short)?.to_vec();
+        p += klen;
+        let off = ibytes
+            .get(p..p + 8)
+            .map(|b| u64::from_le_bytes(b.try_into().expect("8 bytes")))
+            .ok_or_else(short)?;
+        p += 8;
+        let len = crate::commit::get_u32_checked(ibytes, p).ok_or_else(short)?;
+        p += 4;
+        index.push((key, off, len));
+    }
+    if index.len() != block_count {
+        return Err(io::Error::other("run index does not hold the number of blocks the trailer declares"));
+    }
+    Ok(Meta { bloom, index, entry_count, horizon })
+}
+
+/// A block as fetched, checked against the CRC32C it ends in, and handed on
+/// without it. A short ranged GET, a truncated upload or a flipped bit all
+/// end here as an error, never as an entry that is not found.
+fn verify_block(mut raw: Vec<u8>) -> io::Result<Vec<u8>> {
+    let bad = |what: &str| io::Error::new(io::ErrorKind::InvalidData, format!("objkv: {what}"));
+    if raw.len() < BLOCK_CRC_LEN {
+        return Err(bad("run block shorter than its checksum"));
+    }
+    let body_len = raw.len() - BLOCK_CRC_LEN;
+    let want = get_u32(&raw, body_len);
+    if want != crc(&raw[..body_len]) {
+        return Err(bad("run block checksum mismatch"));
+    }
+    raw.truncate(body_len);
+    Ok(raw)
+}
+
+impl<S: RangeSource> Run<S> {
+    /// Two ranged GETs: the trailer, then bloom and index in one call.
+    pub fn open(src: S) -> io::Result<Run<S>> {
+        let meta = read_meta(&src)?;
+        Ok(Run::with_meta(src, meta))
+    }
+
+    /// The same run, parsed from a copy of its bytes already in memory --
+    /// the compactor has just built it -- so the swap costs no round trip.
+    /// Blocks are still read from `src` later.
+    pub fn open_from_bytes(src: S, bytes: &[u8]) -> io::Result<Run<S>> {
+        if bytes.len() as u64 != src.size() {
+            return Err(io::Error::other("run bytes do not match the object size"));
+        }
+        let meta = read_meta(&bytes)?;
+        Ok(Run::with_meta(src, meta))
+    }
+
+    fn with_meta(src: S, meta: Meta) -> Run<S> {
+        Run {
+            src,
+            bloom: meta.bloom,
+            index: meta.index,
+            entry_count: meta.entry_count,
+            horizon: meta.horizon,
+            cache: Mutex::new(BlockCache { cap: DEFAULT_CACHE_BYTES, ..Default::default() }),
+        }
+    }
+
+    /// Where the run is read from: the object it lives in.
+    pub fn source(&self) -> &S {
+        &self.src
+    }
+
+    /// The sequence number of the version live at `snapshot`.
+    pub fn seq_at(&self, row_key: &[u8], snapshot: u64) -> io::Result<Option<u64>> {
+        Ok(self.locate_at(row_key, snapshot)?.and_then(|(k, _)| key::seq_of(&k)))
+    }
+
+    /// The version of `row_key` live at `snapshot`. At most one ranged GET.
+    pub fn get_at(&self, row_key: &[u8], snapshot: u64) -> io::Result<Option<Op>> {
+        Ok(self.locate_at(row_key, snapshot)?.map(|(_, op)| op))
+    }
+
+    /// One block, from the cache or one ranged GET. Verified on the way in,
+    /// so the cache holds only blocks that checked out.
+    fn block_at(&self, off: u64, len: u32) -> io::Result<Vec<u8>> {
+        // Scoped: inlining this into a match holds the guard across the miss
+        // arm and self-deadlocks.
+        let cached = self.cache.lock().unwrap().get(off);
+        match cached {
+            Some(b) => Ok(b),
+            None => {
+                let b = verify_block(self.src.range(off, len as u64)?)?;
+                self.cache.lock().unwrap().insert(off, b.clone());
+                Ok(b)
+            }
+        }
+    }
+
+    /// Every stored key in `[lo, hi)`, in order, stopping once `limit`
+    /// distinct rows have been seen.
+    ///
+    /// Bounds are plain byte strings and the range is half-open, so "greater
+    /// than this value" and "up to and including it" are both expressed by
+    /// where the caller puts the bound rather than by a flag here.
+    ///
+    /// Stored keys carry a version suffix, so one row can appear several
+    /// times; the limit counts rows. Taking the first `limit` from each layer
+    /// and merging afterwards is safe: a key among the first `limit` of the
+    /// union is among the first `limit` of whichever layer holds it.
+    ///
+    /// Versions above `snapshot` are left out here rather than by the caller.
+    /// Counted, they would fill the page with rows the snapshot cannot see,
+    /// and a page that came back short would be mistaken for the end of the
+    /// range.
+    pub fn scan_range_limited(
+        &self,
+        lo: &[u8],
+        hi: &[u8],
+        snapshot: u64,
+        limit: usize,
+    ) -> io::Result<Vec<(Vec<u8>, Op)>> {
+        if self.index.is_empty() || lo >= hi || limit == 0 {
+            return Ok(Vec::new());
+        }
+        let mut rows = 0usize;
+        let mut last: Option<Vec<u8>> = None;
+        let start = match self.index.binary_search_by(|(k, _, _)| k.as_slice().cmp(lo)) {
+            Ok(i) => i,
+            Err(0) => 0,
+            Err(i) => i - 1,
+        };
+        let mut out = Vec::new();
+        for pos in start..self.index.len() {
+            let (first, off, len) = &self.index[pos];
+            // Blocks are ordered: once one starts at or past the upper bound,
+            // so does every block after it.
+            if first.as_slice() >= hi {
+                break;
+            }
+            let block = self.block_at(*off, *len)?;
+            let mut past = false;
+            for (k, op) in decode_block(&block)? {
+                // The bounds name rows, and a caller resuming a page passes
+                // the last row it saw plus a zero byte. That sits below the
+                // row's own versions, which carry `/`, so the whole key would
+                // compare above it and the row would come back twice.
+                if crate::key::row_of(&k).unwrap_or(&k) < lo {
+                    continue;
+                }
+                if k.as_slice() >= hi {
+                    past = true;
+                    break;
+                }
+                if crate::key::seq_of(&k).is_some_and(|seq| seq > snapshot) {
+                    continue;
+                }
+                let row = crate::key::row_of(&k).map(|r| r.to_vec());
+                if row.is_some() && row != last {
+                    if rows == limit {
+                        past = true;
+                        break;
+                    }
+                    rows += 1;
+                    last = row;
+                }
+                out.push((k, op));
+            }
+            if past {
+                break;
+            }
+        }
+        Ok(out)
+    }
+
+    /// The last `limit` rows of `[lo, hi)`, still in ascending order.
+    ///
+    /// Blocks are walked from the top down so a scan reading backwards stops
+    /// as early as a forward one does; ORDER BY ... DESC LIMIT 10 is the whole
+    /// reason it exists.
+    pub fn scan_range_back(
+        &self,
+        lo: &[u8],
+        hi: &[u8],
+        snapshot: u64,
+        limit: usize,
+    ) -> io::Result<Vec<(Vec<u8>, Op)>> {
+        if self.index.is_empty() || lo >= hi || limit == 0 {
+            return Ok(Vec::new());
+        }
+        let mut rows = 0usize;
+        let mut last: Option<Vec<u8>> = None;
+        let mut out: Vec<(Vec<u8>, Op)> = Vec::new();
+        for pos in (0..self.index.len()).rev() {
+            let (first, off, len) = &self.index[pos];
+            // Once a block starts at or past the top of the range, nothing in
+            // it is wanted; once one starts below the bottom, this is the last.
+            if first.as_slice() >= hi {
+                continue;
+            }
+            let block = self.block_at(*off, *len)?;
+            let mut done = false;
+            let entries = decode_block(&block)?;
+            for (k, op) in entries.into_iter().rev() {
+                if k.as_slice() >= hi {
+                    continue;
+                }
+                if crate::key::row_of(&k).unwrap_or(&k) < lo {
+                    done = true;
+                    break;
+                }
+                if crate::key::seq_of(&k).is_some_and(|seq| seq > snapshot) {
+                    continue;
+                }
+                let row = crate::key::row_of(&k).map(|r| r.to_vec());
+                if row.is_some() && row != last {
+                    if rows == limit {
+                        done = true;
+                        break;
+                    }
+                    rows += 1;
+                    last = row;
+                }
+                out.push((k, op));
+            }
+            if done || first.as_slice() <= lo {
+                break;
+            }
+        }
+        out.reverse();
+        Ok(out)
+    }
+
+    /// Every entry whose key starts with `prefix`, in key order.
+    ///
+    /// Seeks rather than scans: the sparse index picks the first block that
+    /// can hold the prefix, and the walk stops at the first key past it. This
+    /// is what makes an index lookup cost a couple of ranged GETs instead of a
+    /// read of the whole run -- the difference between an index being worth
+    /// having and not.
+    pub fn scan_prefix(&self, prefix: &[u8]) -> io::Result<Vec<(Vec<u8>, Op)>> {
+        if self.index.is_empty() {
+            return Ok(Vec::new());
+        }
+        let start = match self.index.binary_search_by(|(k, _, _)| k.as_slice().cmp(prefix)) {
+            Ok(i) => i,
+            Err(0) => 0,
+            Err(i) => i - 1,
+        };
+        let mut out = Vec::new();
+        for pos in start..self.index.len() {
+            let (first, off, len) = &self.index[pos];
+            // Blocks are ordered, so once one starts past the prefix, every
+            // block after it does too.
+            if first.as_slice() > prefix && !first.starts_with(prefix) {
+                break;
+            }
+            let block = self.block_at(*off, *len)?;
+            let mut past = false;
+            for (k, op) in decode_block(&block)? {
+                if k.as_slice() < prefix {
+                    continue;
+                }
+                if !k.starts_with(prefix) {
+                    past = true;
+                    break;
+                }
+                out.push((k, op));
+            }
+            if past {
+                break;
+            }
+        }
+        Ok(out)
+    }
+
+    /// The version of `row_key` live at `snapshot`, with its versioned key,
+    /// so the caller can read the sequence number off it.
+    pub fn locate_at(&self, row_key: &[u8], snapshot: u64) -> io::Result<Option<(Vec<u8>, Op)>> {
+        if !self.bloom.may_contain(row_key) || self.index.is_empty() {
+            return Ok(None);
+        }
+        let probe = key::seek_at(row_key, snapshot);
+        let start = match self.index.binary_search_by(|(k, _, _)| k.as_slice().cmp(&probe)) {
+            Ok(i) => i,
+            Err(0) => 0,
+            Err(i) => i - 1,
+        };
+        // The wanted entry may be the first entry of the next block.
+        for pos in start..self.index.len().min(start + 2) {
+            let (_, off, len) = &self.index[pos];
+            let block = self.block_at(*off, *len)?;
+            if let Some((found, op)) = seek_block(&block, &probe)? {
+                return Ok(key::belongs_to(&found, row_key).then_some((found, op)));
+            }
+        }
+        Ok(None)
+    }
+
+    pub fn block_count(&self) -> usize {
+        self.index.len()
+    }
+
+    /// (hits, misses) against the local block cache.
+    pub fn cache_stats(&self) -> (u64, u64) {
+        let c = self.cache.lock().unwrap();
+        (c.hits, c.misses)
+    }
+
+    pub fn set_cache_bytes(&self, cap: usize) {
+        self.cache.lock().unwrap().cap = cap;
+    }
+
+    /// Every entry in key order, tombstones included. Used by compaction: one
+    /// ranged GET per block, straight from the source and past the cache,
+    /// since nothing it reads will be read again -- the one read path that is
+    /// allowed to be expensive.
+    pub fn scan(&self) -> io::Result<Vec<(Vec<u8>, Op)>> {
+        // No with_capacity on entry_count: it comes off the trailer, which no
+        // checksum covers, and a wrong value here asks the allocator for it.
+        let mut out = Vec::new();
+        for (_, off, len) in &self.index {
+            out.extend(decode_block(&verify_block(self.src.range(*off, *len as u64)?)?)?);
+        }
+        Ok(out)
+    }
+}
+
+/// Every entry in one verified block, in key order.
+///
+/// Still bounds-checked at every step, checksum or no checksum. A run object
+/// arrives over the network like a commit object does, and `commit::decode`
+/// already states the rule: length fields may disagree with the buffer they
+/// came in, and unchecked slicing would take the backend down rather than
+/// report a bad object.
+fn decode_block(block: &[u8]) -> io::Result<Vec<(Vec<u8>, Op)>> {
+    let mut out = Vec::new();
+    let mut p = 0usize;
+    while p + 4 <= block.len() {
+        let (k, tag, value, next) = entry_at(block, p)?;
+        out.push((k.to_vec(), if tag == 0 { Op::Put(value.to_vec()) } else { Op::Delete }));
+        p = next;
+    }
+    Ok(out)
+}
+
+/// First entry at or after `probe` within one block, if any.
+fn seek_block(block: &[u8], probe: &[u8]) -> io::Result<Option<(Vec<u8>, Op)>> {
+    let mut p = 0usize;
+    while p + 4 <= block.len() {
+        let (k, tag, value, next) = entry_at(block, p)?;
+        if k >= probe {
+            return Ok(Some((
+                k.to_vec(),
+                if tag == 0 { Op::Put(value.to_vec()) } else { Op::Delete },
+            )));
+        }
+        p = next;
+    }
+    Ok(None)
+}
+
+/// One encoded entry at `p`: key, tag, value, and where the next one starts.
+fn entry_at(block: &[u8], p: usize) -> io::Result<(&[u8], u8, &[u8], usize)> {
+    fn short<T>() -> io::Result<T> {
+        Err(io::Error::new(io::ErrorKind::InvalidData, "objkv: truncated run block"))
+    }
+    let take = |at: usize, n: usize| -> io::Result<(&[u8], usize)> {
+        match block.get(at..at + n) {
+            Some(s) => Ok((s, at + n)),
+            None => short(),
+        }
+    };
+    let (klen_bytes, p) = take(p, 4)?;
+    let klen = u32::from_le_bytes(klen_bytes.try_into().expect("4 bytes")) as usize;
+    let (k, p) = take(p, klen)?;
+    let (tag_byte, p) = take(p, 1)?;
+    let (vlen_bytes, p) = take(p, 4)?;
+    let vlen = u32::from_le_bytes(vlen_bytes.try_into().expect("4 bytes")) as usize;
+    let (value, p) = take(p, vlen)?;
+    Ok((k, tag_byte[0], value, p))
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::key::LATEST;
+
+    /// Counts ranged reads so tests can assert the round-trip budget, which is
+    /// the whole point of the layout.
+    struct Counting<'a> {
+        bytes: &'a [u8],
+        reads: std::cell::Cell<usize>,
+    }
+    impl RangeSource for Counting<'_> {
+        fn range(&self, offset: u64, len: u64) -> io::Result<Vec<u8>> {
+            self.reads.set(self.reads.get() + 1);
+            self.bytes.range(offset, len)
+        }
+        fn size(&self) -> u64 {
+            self.bytes.len() as u64
+        }
+    }
+
+    fn row(i: usize) -> Vec<u8> {
+        format!("key{i:08}").into_bytes()
+    }
+
+    /// One version of each row, all stamped at seq 1.
+    fn entries(n: usize) -> Vec<(Vec<u8>, Op)> {
+        let mut e: Vec<(Vec<u8>, Op)> = (0..n)
+            .map(|i| (key::versioned(&row(i), 1), Op::Put(vec![b'v'; 100])))
+            .collect();
+        e.sort_by(|a, b| a.0.cmp(&b.0));
+        e
+    }
+
+    #[test]
+    fn finds_every_key_it_stored() {
+        let e = entries(5000);
+        let bytes = build(&e, 0);
+        let run = Run::open(bytes.as_slice()).unwrap();
+        assert_eq!(run.entry_count, 5000);
+        assert!(run.block_count() > 1, "should span several blocks");
+        for (k, v) in &e {
+            let r = key::row_of(k).unwrap();
+            assert_eq!(run.get_at(r, LATEST).unwrap().as_ref(), Some(v));
+        }
+    }
+
+    #[test]
+    fn point_read_costs_one_ranged_get_after_open() {
+        let bytes = build(&entries(5000), 0);
+        let src = Counting { bytes: bytes.as_slice(), reads: std::cell::Cell::new(0) };
+        let run = Run::open(src).unwrap();
+        run.set_cache_bytes(0); // measure raw GETs, not cache behaviour
+        // open() = trailer + (bloom+index) = 2.
+        assert_eq!(run.src.reads.get(), 2);
+        run.get_at(b"key00002500", LATEST).unwrap();
+        assert_eq!(run.src.reads.get(), 3, "a hit must cost exactly one more GET");
+    }
+
+    #[test]
+    fn absent_keys_usually_cost_nothing() {
+        let bytes = build(&entries(2000), 0);
+        let src = Counting { bytes: bytes.as_slice(), reads: std::cell::Cell::new(0) };
+        let run = Run::open(src).unwrap();
+        let before = run.src.reads.get();
+        for i in 0..500 {
+            let k = format!("absent{i:08}");
+            assert!(run.get_at(k.as_bytes(), LATEST).unwrap().is_none());
+        }
+        let fetched = run.src.reads.get() - before;
+        // Bloom should reject nearly all of them without touching a block.
+        assert!(fetched < 50, "bloom let {fetched}/500 misses through to a GET");
+    }
+
+    #[test]
+    fn cache_turns_a_repeat_read_into_zero_gets() {
+        let bytes = build(&entries(5000), 0);
+        let src = Counting { bytes: bytes.as_slice(), reads: std::cell::Cell::new(0) };
+        let run = Run::open(src).unwrap();
+        let k = b"key00002500";
+        run.get_at(k, LATEST).unwrap();
+        let after_first = run.src.reads.get();
+        for _ in 0..100 {
+            run.get_at(k, LATEST).unwrap();
+        }
+        assert_eq!(run.src.reads.get(), after_first, "repeat reads must be free");
+        let (hits, misses) = run.cache_stats();
+        assert_eq!((hits, misses), (100, 1));
+    }
+
+    #[test]
+    fn a_prefix_scan_seeks_instead_of_reading_the_run() {
+        // The property an index lookup lives or dies on. A run holding many
+        // rows must answer "everything under this prefix" with a couple of
+        // ranged GETs, not one per block.
+        let mut e: Vec<(Vec<u8>, Op)> = Vec::new();
+        for i in 0..20_000usize {
+            // Two prefixes, interleaved so neither is contiguous by accident.
+            let p = if i % 2 == 0 { "aaa" } else { "bbb" };
+            e.push((
+                key::versioned(format!("{p}/{i:08}").as_bytes(), 1),
+                Op::Put(vec![b'v'; 60]),
+            ));
+        }
+        e.sort_by(|a, b| a.0.cmp(&b.0));
+        let bytes = build(&e, 0);
+        let src = Counting { bytes: &bytes, reads: Default::default() };
+        let run = Run::open(src).unwrap();
+        assert!(run.block_count() > 10, "needs enough blocks for the test to mean anything");
+
+        let before = run.src.reads.get();
+        let hits = run.scan_prefix(b"aaa/00000042").unwrap();
+        let reads = run.src.reads.get() - before;
+        assert_eq!(hits.len(), 1);
+        assert!(reads <= 2, "a point prefix cost {reads} ranged GETs, not a seek");
+
+        // A wide prefix reads only its own share of the run.
+        let before = run.src.reads.get();
+        let all_a = run.scan_prefix(b"aaa/").unwrap();
+        let reads = run.src.reads.get() - before;
+        assert_eq!(all_a.len(), 10_000);
+        assert!(
+            reads < run.block_count(),
+            "reading half the keys touched {reads} of {} blocks",
+            run.block_count()
+        );
+
+        assert!(run.scan_prefix(b"zzz/").unwrap().is_empty());
+        assert_eq!(run.scan_prefix(b"").unwrap().len(), 20_000);
+    }
+
+    #[test]
+    fn scan_returns_everything_in_key_order() {
+        let e = entries(3000);
+        let bytes = build(&e, 0);
+        let run = Run::open(bytes.as_slice()).unwrap();
+        let got = run.scan().unwrap();
+        assert_eq!(got.len(), e.len());
+        assert!(got.windows(2).all(|w| w[0].0 < w[1].0), "scan must be sorted");
+        assert_eq!(got[0].0, e[0].0);
+    }
+
+    #[test]
+    fn preserves_tombstones() {
+        let mut e = vec![
+            (key::versioned(b"a", 1), Op::Put(b"1".to_vec())),
+            (key::versioned(b"b", 1), Op::Delete),
+        ];
+        e.sort_by(|x, y| x.0.cmp(&y.0));
+        let bytes = build(&e, 0);
+        let run = Run::open(bytes.as_slice()).unwrap();
+        assert_eq!(run.get_at(b"b", LATEST).unwrap(), Some(Op::Delete));
+        assert_eq!(run.get_at(b"c", LATEST).unwrap(), None);
+    }
+
+    #[test]
+    fn a_run_opened_from_its_bytes_reads_no_metadata_over_the_wire() {
+        let bytes = build(&entries(3000), 0);
+        let src = Counting { bytes: bytes.as_slice(), reads: std::cell::Cell::new(0) };
+        let run = Run::open_from_bytes(src, &bytes).unwrap();
+        assert_eq!(run.src.reads.get(), 0, "trailer and index came from memory");
+        assert_eq!(run.entry_count, 3000);
+        assert_eq!(run.get_at(b"key00000042", LATEST).unwrap(), Some(Op::Put(vec![b'v'; 100])));
+        assert_eq!(run.src.reads.get(), 1, "the block itself still comes from the source");
+
+        let short = &bytes[..bytes.len() - 1];
+        assert!(Run::open_from_bytes(short, &bytes).is_err(), "size mismatch is refused");
+    }
+
+    #[test]
+    fn detects_metadata_corruption() {
+        let mut bytes = build(&entries(100), 0);
+        let n = bytes.len();
+        bytes[n - (TRAILER_LEN as usize) - 5] ^= 0xff;
+        assert!(Run::open(bytes.as_slice()).is_err());
+    }
+
+    #[test]
+    fn a_flipped_bit_in_a_block_is_an_error_not_a_missing_row() {
+        // The finding this guards: without a block checksum a flipped key
+        // byte makes the seek skip the entry and the row reads as absent, and
+        // a flipped value byte is served as the value. Every bit of every
+        // block, flipped one at a time, must come back as an error from the
+        // point read that lands on it and from a full scan.
+        let e = entries(40);
+        let good = build(&e, 0);
+        let run = Run::open(good.as_slice()).unwrap();
+        let (_, first_off, first_len) = run.index[0].clone();
+        assert_eq!(first_off, 0);
+        let mut checked = 0;
+        for byte in (0..first_len as usize).step_by(13) {
+            for bit in 0..8 {
+                let mut torn = good.clone();
+                torn[byte] ^= 1 << bit;
+                let run = Run::open(torn.as_slice()).unwrap();
+                run.set_cache_bytes(0);
+                let scan = run.scan();
+                assert!(scan.is_err(), "byte {byte} bit {bit}: scan served a torn block");
+                for (k, _) in &e {
+                    let r = key::row_of(k).unwrap();
+                    let got = run.get_at(r, LATEST);
+                    if !matches!(got, Ok(Some(_)) | Err(_)) {
+                        panic!("byte {byte} bit {bit}: row {:?} read as missing", String::from_utf8_lossy(r));
+                    }
+                    if let Ok(Some(v)) = &got {
+                        assert_eq!(v, &e.iter().find(|(kk, _)| kk == k).unwrap().1, "a wrong value came back");
+                    }
+                }
+                checked += 1;
+            }
+        }
+        assert!(checked > 100);
+        let err = {
+            let mut torn = good.clone();
+            torn[3] ^= 0x01;
+            Run::open(torn.as_slice()).unwrap().scan().unwrap_err()
+        };
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+        assert!(err.to_string().contains("checksum"), "{err}");
+    }
+
+    #[test]
+    fn a_short_block_read_is_an_error_not_a_missing_row() {
+        struct Short<'a>(&'a [u8]);
+        impl RangeSource for Short<'_> {
+            fn range(&self, offset: u64, len: u64) -> io::Result<Vec<u8>> {
+                let full = self.0.range(offset, len)?;
+                // The trailer and metadata come back whole; a block comes back
+                // short, as a ranged GET that was cut off does.
+                if offset + len < self.0.len() as u64 - TRAILER_LEN {
+                    Ok(full[..full.len() / 2].to_vec())
+                } else {
+                    Ok(full)
+                }
+            }
+            fn size(&self) -> u64 {
+                self.0.len() as u64
+            }
+        }
+        let bytes = build(&entries(50), 0);
+        let run = Run::open(Short(&bytes)).unwrap();
+        assert!(run.get_at(b"key00000010", LATEST).is_err());
+        assert!(run.scan().is_err());
+    }
+
+    #[test]
+    fn a_flipped_bit_in_the_trailer_is_detected() {
+        let good = build(&entries(100), 0);
+        let n = good.len();
+        // Every field but the magic (which has its own check) is covered.
+        for byte in n - TRAILER_LEN as usize..n - 4 {
+            let mut torn = good.clone();
+            torn[byte] ^= 0x10;
+            let err = Run::open(torn.as_slice()).map(|_| ()).unwrap_err().to_string();
+            assert!(
+                err.contains("checksum") || err.contains("magic"),
+                "trailer byte {} flipped: {err}",
+                byte - (n - TRAILER_LEN as usize)
+            );
+        }
+    }
+
+    #[test]
+    fn an_older_run_format_is_refused_by_name() {
+        let mut bytes = build(&entries(10), 0);
+        let n = bytes.len();
+        bytes[n - 4..].copy_from_slice(&MAGIC_V2.to_le_bytes());
+        let err = Run::open(bytes.as_slice()).map(|_| ()).unwrap_err().to_string();
+        assert!(err.contains("format 2"), "{err}");
+        assert!(err.contains("format 3"), "{err}");
+        bytes[n - 4..].copy_from_slice(&0xdead_beefu32.to_le_bytes());
+        assert!(Run::open(bytes.as_slice()).map(|_| ()).unwrap_err().to_string().contains("magic"));
+    }
+
+    #[test]
+    fn the_horizon_rides_in_the_trailer() {
+        let e = entries(10);
+        let plain = build(&e, 0);
+        assert_eq!(Run::open(plain.as_slice()).unwrap().horizon, 0);
+        let bytes = build(&e, 42);
+        let run = Run::open(bytes.as_slice()).unwrap();
+        assert_eq!(run.horizon, 42);
+        assert_eq!(run.entry_count, 10, "and the count still reads");
+        let run = Run::open_from_bytes(bytes.as_slice(), &bytes).unwrap();
+        assert_eq!(run.horizon, 42);
+    }
+
+    #[test]
+    fn seal_keys_mirror_run_keys() {
+        assert_eq!(seal_key_for(&key_for(5)), "sealed/0000000000000005");
+        assert_eq!(seal_key_for(&delta_key_for(5)), "sealed/0000000000000005.d");
+        assert_eq!(run_key_of_seal("sealed/0000000000000005.d").as_deref(), Some("run/0000000000000005.d"));
+        assert_eq!(run_key_of_seal(&key_for(5)), None);
+    }
+
+    #[test]
+    fn a_run_answers_at_any_snapshot_it_holds() {
+        // Three versions of one row, plus enough neighbours to span blocks, so
+        // the seek has to do real work rather than land on entry zero.
+        let mut e: Vec<(Vec<u8>, Op)> = Vec::new();
+        for i in 0..2000 {
+            e.push((key::versioned(&row(i), 1), Op::Put(vec![b'p'; 60])));
+        }
+        e.push((key::versioned(&row(900), 4), Op::Put(b"at-four".to_vec())));
+        e.push((key::versioned(&row(900), 9), Op::Put(b"at-nine".to_vec())));
+        e.push((key::versioned(&row(901), 7), Op::Delete));
+        e.sort_by(|a, b| a.0.cmp(&b.0));
+
+        let bytes = build(&e, 0);
+        let run = Run::open(bytes.as_slice()).unwrap();
+        let val = |snap| match run.get_at(&row(900), snap).unwrap() {
+            Some(Op::Put(v)) => String::from_utf8(v).unwrap(),
+            other => panic!("unexpected {other:?}"),
+        };
+        assert_eq!(val(LATEST), "at-nine");
+        assert_eq!(val(9), "at-nine");
+        assert_eq!(val(8), "at-four", "snapshot 8 predates version 9");
+        assert_eq!(val(4), "at-four");
+        assert_eq!(val(3).len(), 60, "before either update, the original");
+        assert_eq!(run.get_at(&row(900), 0).unwrap(), None, "before it existed");
+
+        // A tombstone is a version like any other: visible as deleted after it,
+        // and invisible before it.
+        assert_eq!(run.get_at(&row(901), LATEST).unwrap(), Some(Op::Delete));
+        assert!(matches!(run.get_at(&row(901), 6).unwrap(), Some(Op::Put(_))));
+    }
+
+}

--- a/crates/_support/objkv/src/run.rs
+++ b/crates/_support/objkv/src/run.rs
@@ -26,7 +26,8 @@
 
 use std::collections::HashMap;
 use std::io;
-use std::sync::Mutex;
+use std::sync::Arc;
+use pgsync::Mutex;
 
 use crate::bloom::Bloom;
 use crate::commit::{get_u32, get_u64, put_u32, put_u64, Op};
@@ -83,7 +84,7 @@ pub fn run_key_of_seal(seal_key: &str) -> Option<String> {
 }
 
 fn crc(bytes: &[u8]) -> u32 {
-    crc32c::pg_comp_crc32c(0xffff_ffff, bytes) ^ 0xffff_ffff
+    crate::crc(bytes)
 }
 
 /// Anything a run can be read from: an S3 object, or a byte slice in tests.
@@ -197,7 +198,7 @@ pub struct Run<S: RangeSource> {
 /// random, where the two behave the same and FIFO is simpler to reason about.
 #[derive(Default)]
 struct BlockCache {
-    blocks: HashMap<u64, Vec<u8>>,
+    blocks: HashMap<u64, Arc<[u8]>>,
     order: std::collections::VecDeque<u64>,
     bytes: usize,
     cap: usize,
@@ -206,11 +207,11 @@ struct BlockCache {
 }
 
 impl BlockCache {
-    fn get(&mut self, off: u64) -> Option<Vec<u8>> {
+    fn get(&mut self, off: u64) -> Option<Arc<[u8]>> {
         match self.blocks.get(&off) {
             Some(b) => {
                 self.hits += 1;
-                Some(b.clone())
+                Some(Arc::clone(b))
             }
             None => {
                 self.misses += 1;
@@ -218,8 +219,13 @@ impl BlockCache {
             }
         }
     }
-    fn insert(&mut self, off: u64, block: Vec<u8>) {
+    fn insert(&mut self, off: u64, block: Arc<[u8]>) {
         if self.cap == 0 || block.len() > self.cap {
+            return;
+        }
+        // Two readers can miss the same block and both arrive here; counting
+        // it twice leaks capacity, since eviction subtracts it once.
+        if self.blocks.contains_key(&off) {
             return;
         }
         while self.bytes + block.len() > self.cap {
@@ -377,15 +383,15 @@ impl<S: RangeSource> Run<S> {
 
     /// One block, from the cache or one ranged GET. Verified on the way in,
     /// so the cache holds only blocks that checked out.
-    fn block_at(&self, off: u64, len: u32) -> io::Result<Vec<u8>> {
+    fn block_at(&self, off: u64, len: u32) -> io::Result<Arc<[u8]>> {
         // Scoped: inlining this into a match holds the guard across the miss
         // arm and self-deadlocks.
         let cached = self.cache.lock().unwrap().get(off);
         match cached {
             Some(b) => Ok(b),
             None => {
-                let b = verify_block(self.src.range(off, len as u64)?)?;
-                self.cache.lock().unwrap().insert(off, b.clone());
+                let b: Arc<[u8]> = verify_block(self.src.range(off, len as u64)?)?.into();
+                self.cache.lock().unwrap().insert(off, Arc::clone(&b));
                 Ok(b)
             }
         }

--- a/crates/_support/objkv/src/s3.rs
+++ b/crates/_support/objkv/src/s3.rs
@@ -1,0 +1,427 @@
+//! S3 client: `ureq` for transport (blocking, TLS, pooled connections),
+//! `rusty-s3` for request construction and SigV4 presigning -- synchronous, so
+//! it suits a thread-per-backend server, and it supplies the S3 semantics
+//! (ListObjectsV2 parsing especially) this used to reimplement badly.
+//!
+//! Signing is by presigned URL, so bodies are never hashed: the payload hash
+//! is `UNSIGNED-PAYLOAD`.
+
+use std::io::{self, Read};
+use std::time::Duration;
+
+use rusty_s3::actions::{ListObjectsV2, S3Action};
+use rusty_s3::{Bucket, Credentials, UrlStyle};
+
+/// Socket deadline. Without one a network black hole becomes an unbounded
+/// stall, which is the failure mode that matters most here.
+pub const REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// How long a presigned URL stays valid; it only has to cover clock skew.
+const SIGN_EXPIRY: Duration = Duration::from_secs(300);
+
+/// Attempts per request, including the first. Transport failures and 5xx are
+/// retried; every 4xx except the conditional-write conflict is permanent.
+const MAX_ATTEMPTS: u32 = 4;
+const RETRY_BASE_DELAY: Duration = Duration::from_millis(50);
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum PutOutcome {
+    Written,
+    /// The key already existed; `If-None-Match: *` was refused.
+    AlreadyExists,
+}
+
+#[derive(Debug)]
+pub struct ObjectInfo {
+    pub key: String,
+    pub size: u64,
+}
+
+
+pub struct Client {
+    agent: ureq::Agent,
+    bucket: Bucket,
+    creds: Credentials,
+}
+
+impl Client {
+    /// Path-style addressing: virtual-host style needs per-bucket DNS.
+    pub fn new(
+        endpoint: &str,
+        bucket: &str,
+        region: &str,
+        access_key: &str,
+        secret_key: &str,
+    ) -> io::Result<Client> {
+        let url = endpoint
+            .parse()
+            .map_err(|e| io::Error::other(format!("bad S3 endpoint {endpoint:?}: {e}")))?;
+        let bucket = Bucket::new(url, UrlStyle::Path, bucket.to_string(), region.to_string())
+            .map_err(|e| io::Error::other(format!("bad S3 bucket: {e}")))?;
+        Ok(Client {
+            agent: ureq::AgentBuilder::new()
+                .timeout_read(REQUEST_TIMEOUT)
+                .timeout_write(REQUEST_TIMEOUT)
+                .timeout_connect(REQUEST_TIMEOUT)
+                // Never follow a redirect. S3 answers 301/307 for a bucket in
+                // another region or one just created; ureq would re-send a
+                // PUT as a GET, or hand back the 3xx as success, and either
+                // way a commit that never landed would be acknowledged. A
+                // redirect is a misconfiguration and is reported as one.
+                .redirects(0)
+                .build(),
+            bucket,
+            creds: Credentials::new(access_key, secret_key),
+        })
+    }
+
+    pub fn new_with_token(
+        endpoint: &str,
+        bucket: &str,
+        region: &str,
+        access_key: &str,
+        secret_key: &str,
+        token: &str,
+    ) -> io::Result<Client> {
+        let mut c = Client::new(endpoint, bucket, region, access_key, secret_key)?;
+        c.creds = Credentials::new_with_token(access_key, secret_key, token);
+        Ok(c)
+    }
+
+    /// `PUT` with `If-None-Match: *` — the primitive the whole design rests on.
+    /// Only a 2xx is `Written`; `execute` turns everything else into an error.
+    pub fn put_if_absent(&self, key: &str, body: &[u8]) -> io::Result<PutOutcome> {
+        let mut action = self.bucket.put_object(Some(&self.creds), key);
+        action.headers_mut().insert("if-none-match", "*");
+        let url = action.sign(SIGN_EXPIRY);
+        let hdrs = [("if-none-match", "*")];
+
+        match self.execute("PUT", url.as_str(), &hdrs, Some(body)) {
+            Ok(_) => Ok(PutOutcome::Written),
+            // 412 is the conditional-write refusal: the key exists, we lost. 409 is
+            // deliberately not folded in -- S3 returns it when a concurrent request for
+            // the same key is in flight and documents it as retryable, so the outcome is
+            // unknown rather than lost. `execute` retries it.
+            Err(Fail::Status(412, _)) => Ok(PutOutcome::AlreadyExists),
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    pub fn get(&self, key: &str) -> io::Result<Option<Vec<u8>>> {
+        let url = self.bucket.get_object(Some(&self.creds), key).sign(SIGN_EXPIRY);
+        match self.execute("GET", url.as_str(), &[], None) {
+            Ok(r) => Ok(Some(r.body)),
+            Err(Fail::Status(404, _)) => Ok(None),
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    /// Ranged GET — what makes a cold point-read one round trip instead of
+    /// downloading a whole sorted run.
+    pub fn get_range(&self, key: &str, offset: u64, len: u64) -> io::Result<Option<Vec<u8>>> {
+        // `offset + len - 1` underflows on a zero-length range.
+        if len == 0 {
+            return Ok(Some(Vec::new()));
+        }
+        let range = format!("bytes={offset}-{}", offset + len - 1);
+        let mut action = self.bucket.get_object(Some(&self.creds), key);
+        action.headers_mut().insert("range", range.clone());
+        let url = action.sign(SIGN_EXPIRY);
+        let hdrs = [("range", range.as_str())];
+
+        match self.execute("GET", url.as_str(), &hdrs, None) {
+            Ok(r) => {
+                // A store that ignores `Range` answers 200 with the whole object, handing
+                // the run reader a file where it expected a block. The status is the only
+                // thing that distinguishes them.
+                if r.status != 206 {
+                    return Err(io::Error::other(format!(
+                        "s3: ranged GET of {key} returned status {}, not 206; \
+                         the store ignored the Range header",
+                        r.status
+                    )));
+                }
+                Ok(Some(r.body))
+            }
+            Err(Fail::Status(404, _)) => Ok(None),
+            // A range past the end of the object.
+            Err(Fail::Status(416, _)) => Ok(None),
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    /// A 404 is success: a retried delete must not fail the second time.
+    pub fn delete(&self, key: &str) -> io::Result<()> {
+        let url = self.bucket.delete_object(Some(&self.creds), key).sign(SIGN_EXPIRY);
+        match self.execute("DELETE", url.as_str(), &[], None) {
+            Ok(_) | Err(Fail::Status(404, _)) => Ok(()),
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    /// `ListObjectsV2`, following continuation tokens to completion. Pagination is
+    /// not optional: 1000 keys per call, and ignoring the token passes every small
+    /// test and then truncates recovery at scale.
+    pub fn list(&self, prefix: &str) -> io::Result<Vec<ObjectInfo>> {
+        let mut out = Vec::new();
+        let mut token: Option<String> = None;
+        loop {
+            let mut action: ListObjectsV2 = self.bucket.list_objects_v2(Some(&self.creds));
+            action.with_prefix(prefix.to_string());
+            action.with_max_keys(1000);
+            if let Some(t) = &token {
+                action.with_continuation_token(t.clone());
+            }
+            let url = action.sign(SIGN_EXPIRY);
+            let body = self
+                .execute("GET", url.as_str(), &[], None)
+                .map_err(io::Error::from)?
+                .body;
+            // Real XML parsing: a key containing `&` arrives as `&amp;`, and the
+            // substring scanner this replaced handed it back verbatim.
+            let text = String::from_utf8(body)
+                .map_err(|e| io::Error::other(format!("s3 list: non-UTF-8 response: {e}")))?;
+            let parsed = ListObjectsV2::parse_response(&text)
+                .map_err(|e| io::Error::other(format!("s3 list: malformed XML: {e}")))?;
+            out.extend(parsed.contents.into_iter().map(|c| ObjectInfo {
+                key: c.key,
+                size: c.size,
+            }));
+            match parsed.next_continuation_token {
+                Some(t) => token = Some(t),
+                None => return Ok(out),
+            }
+        }
+    }
+
+    /// One HTTP exchange, retried on failures that are actually transient.
+    fn execute(
+        &self,
+        method: &str,
+        url: &str,
+        headers: &[(&str, &str)],
+        body: Option<&[u8]>,
+    ) -> Result<Response, Fail> {
+        let mut attempt = 0;
+        loop {
+            attempt += 1;
+            match self.send_once(method, url, headers, body) {
+                Ok(r) => return Ok(r),
+                Err(e) if e.retryable() && attempt < MAX_ATTEMPTS => {
+                    std::thread::sleep(RETRY_BASE_DELAY * (1 << (attempt - 1)));
+                }
+                Err(e) => return Err(e),
+            }
+        }
+    }
+
+    fn send_once(
+        &self,
+        method: &str,
+        url: &str,
+        headers: &[(&str, &str)],
+        body: Option<&[u8]>,
+    ) -> Result<Response, Fail> {
+        let mut req = self.agent.request(method, url);
+        for (k, v) in headers {
+            req = req.set(k, v);
+        }
+        let resp = match body {
+            Some(b) => req.send_bytes(b),
+            None => req.call(),
+        };
+        match resp {
+            Ok(r) => {
+                let status = r.status();
+                let mut buf = Vec::new();
+                r.into_reader()
+                    .read_to_end(&mut buf)
+                    .map_err(|e| Fail::Transport(e.to_string()))?;
+                // ureq reports only 4xx and 5xx as errors; a 3xx (or anything
+                // else outside 2xx) comes back here as `Ok`, and would pass for
+                // a stored object. Success is 2xx and nothing else.
+                if !(200..300).contains(&status) {
+                    return Err(Fail::Status(status, String::from_utf8_lossy(&buf).into_owned()));
+                }
+                Ok(Response { status, body: buf })
+            }
+            Err(ureq::Error::Status(code, r)) => {
+                Err(Fail::Status(code, r.into_string().unwrap_or_default()))
+            }
+            Err(e) => Err(Fail::Transport(e.to_string())),
+        }
+    }
+}
+
+struct Response {
+    status: u16,
+    body: Vec<u8>,
+}
+
+/// Distinguishes a refused request from a broken connection, which is what the
+/// retry loop in `execute` needs.
+#[derive(Debug)]
+enum Fail {
+    Status(u16, String),
+    Transport(String),
+}
+
+impl Fail {
+    fn retryable(&self) -> bool {
+        match self {
+            // A dropped connection says nothing about whether the request applied, but
+            // every operation here is idempotent or guarded by put-if-absent.
+            Fail::Transport(_) => true,
+            Fail::Status(409, _) => true,
+            Fail::Status(429, _) => true,
+            Fail::Status(c, _) => *c >= 500,
+        }
+    }
+}
+
+impl From<Fail> for io::Error {
+    fn from(f: Fail) -> io::Error {
+        match f {
+            // char_indices, not a byte slice: keys are arbitrary UTF-8 and S3 echoes
+            // them into error bodies, so a byte cut can split a codepoint and panic.
+            Fail::Status(code, body) => {
+                let cut = body
+                    .char_indices()
+                    .map(|(i, _)| i)
+                    .chain([body.len()])
+                    .take_while(|&i| i <= 512)
+                    .last()
+                    .unwrap_or(0);
+                io::Error::other(format!("s3 status {code}: {}", &body[..cut]))
+            }
+            Fail::Transport(e) => io::Error::other(format!("s3 transport: {e}")),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn client(endpoint: &str) -> Client {
+        Client::new(endpoint, "b", "us-east-1", "k", "s").unwrap()
+    }
+
+    #[test]
+    fn path_style_urls_name_the_bucket_in_the_path() {
+        let c = client("http://127.0.0.1:9000");
+        let url = c.bucket.get_object(Some(&c.creds), "run/000a").sign(SIGN_EXPIRY);
+        assert_eq!(url.host_str(), Some("127.0.0.1"));
+        assert_eq!(url.port(), Some(9000));
+        assert_eq!(url.path(), "/b/run/000a");
+        assert!(url.query().unwrap().contains("X-Amz-Signature="));
+    }
+
+    #[test]
+    fn object_keys_are_encoded_but_keep_separators() {
+        let c = client("http://h");
+        let url = c.bucket.get_object(Some(&c.creds), "a b").sign(SIGN_EXPIRY);
+        assert_eq!(url.path(), "/b/a%20b");
+    }
+
+    #[test]
+    fn conditional_header_is_signed_into_the_url() {
+        let c = client("http://h");
+        let mut a = c.bucket.put_object(Some(&c.creds), "k");
+        a.headers_mut().insert("if-none-match", "*");
+        let signed = a.sign(SIGN_EXPIRY);
+        let q = signed.query().unwrap();
+        assert!(
+            q.contains("if-none-match"),
+            "if-none-match must appear in X-Amz-SignedHeaders, got {q}"
+        );
+    }
+
+    #[test]
+    fn list_responses_decode_xml_entities() {
+        let xml = "<ListBucketResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">\
+                   <Name>b</Name><KeyCount>1</KeyCount><MaxKeys>1000</MaxKeys>\
+                   <IsTruncated>false</IsTruncated>\
+                   <Contents><Key>a&amp;b</Key><Size>10</Size>\
+                   <LastModified>2024-01-01T00:00:00.000Z</LastModified>\
+                   <ETag>\"x\"</ETag></Contents></ListBucketResult>";
+        let r = ListObjectsV2::parse_response(xml).unwrap();
+        assert_eq!(r.contents.len(), 1);
+        assert_eq!(r.contents[0].key, "a&b");
+        assert_eq!(r.contents[0].size, 10);
+    }
+
+    #[test]
+    fn retry_classification() {
+        assert!(Fail::Transport("reset".into()).retryable());
+        assert!(Fail::Status(409, String::new()).retryable());
+        assert!(Fail::Status(503, String::new()).retryable());
+        assert!(!Fail::Status(412, String::new()).retryable());
+        assert!(!Fail::Status(404, String::new()).retryable());
+        assert!(!Fail::Status(403, String::new()).retryable());
+        assert!(!Fail::Status(301, String::new()).retryable(), "a redirect is a misconfiguration");
+        assert!(!Fail::Status(307, String::new()).retryable());
+    }
+
+    /// One HTTP exchange served by hand on a local socket, answering with
+    /// the given status line and no body, and returning the request line.
+    fn serve_once(status_line: &'static str) -> (String, std::thread::JoinHandle<String>) {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let h = std::thread::spawn(move || {
+            use std::io::{BufRead, BufReader, Write};
+            let (mut sock, _) = listener.accept().unwrap();
+            let mut reader = BufReader::new(sock.try_clone().unwrap());
+            let mut request = String::new();
+            reader.read_line(&mut request).unwrap();
+            // Drain the headers so the client's body write does not fail.
+            let mut line = String::new();
+            let mut content_length = 0usize;
+            loop {
+                line.clear();
+                reader.read_line(&mut line).unwrap();
+                if let Some(v) = line.to_ascii_lowercase().strip_prefix("content-length:") {
+                    content_length = v.trim().parse().unwrap_or(0);
+                }
+                if line == "\r\n" || line.is_empty() {
+                    break;
+                }
+            }
+            let mut body = vec![0u8; content_length];
+            std::io::Read::read_exact(&mut reader, &mut body).unwrap();
+            let reply = format!(
+                "HTTP/1.1 {status_line}\r\nLocation: http://127.0.0.1:1/elsewhere\r\n\
+                 Content-Length: 0\r\nConnection: close\r\n\r\n"
+            );
+            sock.write_all(reply.as_bytes()).unwrap();
+            request
+        });
+        (format!("http://{addr}"), h)
+    }
+
+    #[test]
+    fn a_redirected_put_is_an_error_not_a_write() {
+        for status in ["307 Temporary Redirect", "301 Moved Permanently"] {
+            let (endpoint, server) = serve_once(status);
+            let c = client(&endpoint);
+            let err = c.put_if_absent("commit/1", b"x").unwrap_err().to_string();
+            let code = &status[..3];
+            assert!(err.contains(&format!("s3 status {code}")), "got: {err}");
+            let request = server.join().unwrap();
+            assert!(request.starts_with("PUT "), "the redirect was not followed: {request}");
+        }
+    }
+
+    #[test]
+    fn a_redirected_get_or_delete_is_an_error_too() {
+        let (endpoint, server) = serve_once("302 Found");
+        let err = client(&endpoint).get("k").unwrap_err().to_string();
+        assert!(err.contains("s3 status 302"), "got: {err}");
+        server.join().unwrap();
+
+        let (endpoint, server) = serve_once("307 Temporary Redirect");
+        let err = client(&endpoint).delete("k").unwrap_err().to_string();
+        assert!(err.contains("s3 status 307"), "got: {err}");
+        server.join().unwrap();
+    }
+}

--- a/crates/_support/objkv/src/s3.rs
+++ b/crates/_support/objkv/src/s3.rs
@@ -13,21 +13,32 @@ use rusty_s3::actions::{ListObjectsV2, S3Action};
 use rusty_s3::{Bucket, Credentials, UrlStyle};
 
 /// Socket deadline. Without one a network black hole becomes an unbounded
-/// stall, which is the failure mode that matters most here.
-pub const REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
+/// stall, which is the failure mode that matters most here. Short enough
+/// that a lease renewal (one PUT and one LIST, each retried to this limit)
+/// fits inside the lease's validity.
+pub const REQUEST_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// How long a presigned URL stays valid; it only has to cover clock skew.
 const SIGN_EXPIRY: Duration = Duration::from_secs(300);
 
 /// Attempts per request, including the first. Transport failures and 5xx are
 /// retried; every 4xx except the conditional-write conflict is permanent.
-const MAX_ATTEMPTS: u32 = 4;
-const RETRY_BASE_DELAY: Duration = Duration::from_millis(50);
+const MAX_ATTEMPTS: u32 = 3;
+/// Backoff between attempts: doubling from this, capped, with full jitter so
+/// the threads that all hit one throttled prefix do not come back in step.
+const RETRY_BASE_DELAY: Duration = Duration::from_millis(100);
+const RETRY_MAX_DELAY: Duration = Duration::from_secs(2);
+/// The most a `Retry-After` header is believed.
+const RETRY_AFTER_CAP: Duration = Duration::from_secs(5);
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum PutOutcome {
     Written,
-    /// The key already existed; `If-None-Match: *` was refused.
+    /// The key already existed when the PUT was tried: `If-None-Match: *` was
+    /// refused. That is not always "somebody else won". `execute` re-sends a
+    /// PUT whose response was lost, and if the first attempt landed the
+    /// retry is refused by our own object. A caller that cannot rule that out
+    /// reads the key back and compares before treating the write as lost.
     AlreadyExists,
 }
 
@@ -98,11 +109,13 @@ impl Client {
 
         match self.execute("PUT", url.as_str(), &hdrs, Some(body)) {
             Ok(_) => Ok(PutOutcome::Written),
-            // 412 is the conditional-write refusal: the key exists, we lost. 409 is
-            // deliberately not folded in -- S3 returns it when a concurrent request for
-            // the same key is in flight and documents it as retryable, so the outcome is
-            // unknown rather than lost. `execute` retries it.
-            Err(Fail::Status(412, _)) => Ok(PutOutcome::AlreadyExists),
+            // 412 is the conditional-write refusal: the key exists -- see
+            // `PutOutcome::AlreadyExists` for why that is not always a loss.
+            // 409 is deliberately not folded in -- S3 returns it when a
+            // concurrent request for the same key is in flight and documents
+            // it as retryable, so the outcome is unknown rather than lost.
+            // `execute` retries it.
+            Err(Fail::Status(412, ..)) => Ok(PutOutcome::AlreadyExists),
             Err(e) => Err(e.into()),
         }
     }
@@ -111,7 +124,7 @@ impl Client {
         let url = self.bucket.get_object(Some(&self.creds), key).sign(SIGN_EXPIRY);
         match self.execute("GET", url.as_str(), &[], None) {
             Ok(r) => Ok(Some(r.body)),
-            Err(Fail::Status(404, _)) => Ok(None),
+            Err(Fail::Status(404, ..)) => Ok(None),
             Err(e) => Err(e.into()),
         }
     }
@@ -143,9 +156,12 @@ impl Client {
                 }
                 Ok(Some(r.body))
             }
-            Err(Fail::Status(404, _)) => Ok(None),
-            // A range past the end of the object.
-            Err(Fail::Status(416, _)) => Ok(None),
+            Err(Fail::Status(404, ..)) => Ok(None),
+            // A range past the end of the object is a short object, not an
+            // absent one: the run reader must hear "corrupt", never "gone".
+            Err(Fail::Status(416, ..)) => Err(io::Error::other(format!(
+                "s3: ranged GET of {key} at {offset}+{len} is past the end of the object"
+            ))),
             Err(e) => Err(e.into()),
         }
     }
@@ -154,7 +170,7 @@ impl Client {
     pub fn delete(&self, key: &str) -> io::Result<()> {
         let url = self.bucket.delete_object(Some(&self.creds), key).sign(SIGN_EXPIRY);
         match self.execute("DELETE", url.as_str(), &[], None) {
-            Ok(_) | Err(Fail::Status(404, _)) => Ok(()),
+            Ok(_) | Err(Fail::Status(404, ..)) => Ok(()),
             Err(e) => Err(e.into()),
         }
     }
@@ -208,7 +224,7 @@ impl Client {
             match self.send_once(method, url, headers, body) {
                 Ok(r) => return Ok(r),
                 Err(e) if e.retryable() && attempt < MAX_ATTEMPTS => {
-                    std::thread::sleep(RETRY_BASE_DELAY * (1 << (attempt - 1)));
+                    pgsync::thread::sleep(backoff(attempt, e.retry_after()));
                 }
                 Err(e) => return Err(e),
             }
@@ -241,12 +257,16 @@ impl Client {
                 // else outside 2xx) comes back here as `Ok`, and would pass for
                 // a stored object. Success is 2xx and nothing else.
                 if !(200..300).contains(&status) {
-                    return Err(Fail::Status(status, String::from_utf8_lossy(&buf).into_owned()));
+                    return Err(Fail::Status(status, String::from_utf8_lossy(&buf).into_owned(), None));
                 }
                 Ok(Response { status, body: buf })
             }
             Err(ureq::Error::Status(code, r)) => {
-                Err(Fail::Status(code, r.into_string().unwrap_or_default()))
+                let retry_after = r
+                    .header("retry-after")
+                    .and_then(|v| v.trim().parse::<u64>().ok())
+                    .map(Duration::from_secs);
+                Err(Fail::Status(code, r.into_string().unwrap_or_default(), retry_after))
             }
             Err(e) => Err(Fail::Transport(e.to_string())),
         }
@@ -262,21 +282,48 @@ struct Response {
 /// retry loop in `execute` needs.
 #[derive(Debug)]
 enum Fail {
-    Status(u16, String),
+    /// Status, body, and the `Retry-After` the store asked for, if any.
+    Status(u16, String, Option<Duration>),
     Transport(String),
 }
 
 impl Fail {
     fn retryable(&self) -> bool {
         match self {
-            // A dropped connection says nothing about whether the request applied, but
-            // every operation here is idempotent or guarded by put-if-absent.
+            // A dropped connection says nothing about whether the request
+            // applied. GET, LIST and DELETE do not care; a PUT is conditional,
+            // so a retry of one that landed is refused rather than repeated,
+            // and the caller reads back to tell the two apart (see
+            // `PutOutcome::AlreadyExists`).
             Fail::Transport(_) => true,
-            Fail::Status(409, _) => true,
-            Fail::Status(429, _) => true,
-            Fail::Status(c, _) => *c >= 500,
+            Fail::Status(409, ..) => true,
+            Fail::Status(429, ..) => true,
+            Fail::Status(c, ..) => *c >= 500,
         }
     }
+
+    fn retry_after(&self) -> Option<Duration> {
+        match self {
+            Fail::Status(_, _, after) => *after,
+            Fail::Transport(_) => None,
+        }
+    }
+}
+
+/// Capped exponential backoff with full jitter, or the store's own
+/// `Retry-After` (capped) when it named one.
+fn backoff(attempt: u32, retry_after: Option<Duration>) -> Duration {
+    if let Some(after) = retry_after {
+        return after.min(RETRY_AFTER_CAP);
+    }
+    let ceiling = (RETRY_BASE_DELAY * (1 << (attempt - 1).min(8))).min(RETRY_MAX_DELAY);
+    // Not a secret and not a statistic: any spread across threads will do.
+    let mut x = pg_clock::wall_ns() as u64 ^ (u64::from(std::process::id()) << 20);
+    x ^= x >> 12;
+    x ^= x << 25;
+    x ^= x >> 27;
+    let frac = (x.wrapping_mul(0x2545_f491_4f6c_dd1d) >> 11) as f64 / (1u64 << 53) as f64;
+    Duration::from_secs_f64(ceiling.as_secs_f64() * frac)
 }
 
 impl From<Fail> for io::Error {
@@ -284,7 +331,7 @@ impl From<Fail> for io::Error {
         match f {
             // char_indices, not a byte slice: keys are arbitrary UTF-8 and S3 echoes
             // them into error bodies, so a byte cut can split a codepoint and panic.
-            Fail::Status(code, body) => {
+            Fail::Status(code, body, _) => {
                 let cut = body
                     .char_indices()
                     .map(|(i, _)| i)
@@ -354,13 +401,13 @@ mod tests {
     #[test]
     fn retry_classification() {
         assert!(Fail::Transport("reset".into()).retryable());
-        assert!(Fail::Status(409, String::new()).retryable());
-        assert!(Fail::Status(503, String::new()).retryable());
-        assert!(!Fail::Status(412, String::new()).retryable());
-        assert!(!Fail::Status(404, String::new()).retryable());
-        assert!(!Fail::Status(403, String::new()).retryable());
-        assert!(!Fail::Status(301, String::new()).retryable(), "a redirect is a misconfiguration");
-        assert!(!Fail::Status(307, String::new()).retryable());
+        assert!(Fail::Status(409, String::new(), None).retryable());
+        assert!(Fail::Status(503, String::new(), None).retryable());
+        assert!(!Fail::Status(412, String::new(), None).retryable());
+        assert!(!Fail::Status(404, String::new(), None).retryable());
+        assert!(!Fail::Status(403, String::new(), None).retryable());
+        assert!(!Fail::Status(301, String::new(), None).retryable(), "a redirect is a misconfiguration");
+        assert!(!Fail::Status(307, String::new(), None).retryable());
     }
 
     /// One HTTP exchange served by hand on a local socket, answering with

--- a/crates/_support/objkv/src/store.rs
+++ b/crates/_support/objkv/src/store.rs
@@ -1,0 +1,119 @@
+//! The object-store interface the storage layer is written against, plus an
+//! in-memory implementation that exists for tests only: the read path, commits
+//! and compaction can be exercised without a network. The server never selects
+//! it; a cluster without an object store has no objkv storage.
+
+use std::collections::BTreeMap;
+use std::io;
+use std::sync::{Arc, Mutex};
+
+use crate::run::RangeSource;
+use crate::s3::Client;
+use crate::s3::{ObjectInfo, PutOutcome};
+
+pub trait Store: Send + Sync {
+    fn put_if_absent(&self, key: &str, body: &[u8]) -> io::Result<PutOutcome>;
+    fn get(&self, key: &str) -> io::Result<Option<Vec<u8>>>;
+    fn get_range(&self, key: &str, offset: u64, len: u64) -> io::Result<Option<Vec<u8>>>;
+    fn list(&self, prefix: &str) -> io::Result<Vec<ObjectInfo>>;
+    /// Removes an object; succeeds if it was already gone.
+    ///
+    /// The only destructive operation here. Everything else in this design is
+    /// append-only, which is why a crash has never been able to lose data --
+    /// an interrupted write leaves rubbish, not a hole. This one can, so it
+    /// is only ever pointed at what is provably garbage: a replaced run after
+    /// its replacement has been read back, a folded commit object, a marker
+    /// or lease object the bucket no longer needs.
+    fn delete(&self, key: &str) -> io::Result<()>;
+}
+
+impl Store for Client {
+    fn put_if_absent(&self, key: &str, body: &[u8]) -> io::Result<PutOutcome> {
+        Client::put_if_absent(self, key, body)
+    }
+    fn get(&self, key: &str) -> io::Result<Option<Vec<u8>>> {
+        Client::get(self, key)
+    }
+    fn get_range(&self, key: &str, offset: u64, len: u64) -> io::Result<Option<Vec<u8>>> {
+        Client::get_range(self, key, offset, len)
+    }
+    fn list(&self, prefix: &str) -> io::Result<Vec<ObjectInfo>> {
+        Client::list(self, prefix)
+    }
+    fn delete(&self, key: &str) -> io::Result<()> {
+        Client::delete(self, key)
+    }
+}
+
+/// In-memory store. Counts requests, because the round-trip budget is the
+/// thing the design lives or dies on.
+#[derive(Default)]
+pub struct MemStore {
+    objects: Mutex<BTreeMap<String, Vec<u8>>>,
+}
+
+impl MemStore {
+    pub fn new() -> MemStore {
+        MemStore::default()
+    }
+}
+
+impl Store for MemStore {
+    fn put_if_absent(&self, key: &str, body: &[u8]) -> io::Result<PutOutcome> {
+        let mut o = self.objects.lock().unwrap();
+        if o.contains_key(key) {
+            return Ok(PutOutcome::AlreadyExists);
+        }
+        o.insert(key.to_string(), body.to_vec());
+        Ok(PutOutcome::Written)
+    }
+    fn get(&self, key: &str) -> io::Result<Option<Vec<u8>>> {
+        Ok(self.objects.lock().unwrap().get(key).cloned())
+    }
+    fn get_range(&self, key: &str, offset: u64, len: u64) -> io::Result<Option<Vec<u8>>> {
+        let o = self.objects.lock().unwrap();
+        let Some(b) = o.get(key) else { return Ok(None) };
+        let s = usize::try_from(offset).map_err(|_| io::Error::other("range offset overflow"))?;
+        let e = offset
+            .checked_add(len)
+            .and_then(|e| usize::try_from(e).ok())
+            .map_or(b.len(), |e| e.min(b.len()));
+        if s > b.len() {
+            return Err(io::Error::other("range past end of object"));
+        }
+        Ok(Some(b[s..e].to_vec()))
+    }
+    fn list(&self, prefix: &str) -> io::Result<Vec<ObjectInfo>> {
+        Ok(self
+            .objects
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|(k, _)| k.starts_with(prefix))
+            .map(|(k, v)| ObjectInfo { key: k.clone(), size: v.len() as u64 })
+            .collect())
+    }
+    fn delete(&self, key: &str) -> io::Result<()> {
+        self.objects.lock().unwrap().remove(key);
+        Ok(())
+    }
+}
+
+/// Adapts one stored object into a `RangeSource` so runs can be read in place
+/// rather than downloaded.
+pub struct ObjectRange {
+    pub store: Arc<dyn Store>,
+    pub key: String,
+    pub size: u64,
+}
+
+impl RangeSource for ObjectRange {
+    fn range(&self, offset: u64, len: u64) -> io::Result<Vec<u8>> {
+        self.store
+            .get_range(&self.key, offset, len)?
+            .ok_or_else(|| io::Error::other(format!("object vanished: {}", self.key)))
+    }
+    fn size(&self) -> u64 {
+        self.size
+    }
+}

--- a/crates/_support/objkv/src/store.rs
+++ b/crates/_support/objkv/src/store.rs
@@ -5,7 +5,8 @@
 
 use std::collections::BTreeMap;
 use std::io;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
+use pgsync::Mutex;
 
 use crate::run::RangeSource;
 use crate::s3::Client;
@@ -14,6 +15,9 @@ use crate::s3::{ObjectInfo, PutOutcome};
 pub trait Store: Send + Sync {
     fn put_if_absent(&self, key: &str, body: &[u8]) -> io::Result<PutOutcome>;
     fn get(&self, key: &str) -> io::Result<Option<Vec<u8>>>;
+    /// `None` only when the object is absent. A range that does not fit the
+    /// object is an error, on every implementation alike, so a short or torn
+    /// object is never mistaken for a deleted one.
     fn get_range(&self, key: &str, offset: u64, len: u64) -> io::Result<Option<Vec<u8>>>;
     fn list(&self, prefix: &str) -> io::Result<Vec<ObjectInfo>>;
     /// Removes an object; succeeds if it was already gone.

--- a/crates/_support/seams_init/tests/lint-determinism.allow
+++ b/crates/_support/seams_init/tests/lint-determinism.allow
@@ -873,14 +873,12 @@ spawn	crates/backend/executor/execmain/src/lanev2/stmt_task.rs	1	DST-REVIEW(nigh
 fs	crates/backend/access/parquet_read/src/lib.rs	5	DST-REVIEW(t46 compose, night/parquet-reader): the reader crate's footer/dictionary/page positioned reads (File::open + pread class, read-only COPY FORMAT parquet source; the branch never paid its ledger — no standard CONFIRM ran there); P1 Vfs choke routing rides the crate-wide migration
 fs	crates/backend/commands/copy/src/memheadroom.rs	2	DST-REVIEW(night/copyfast): kernel pseudo-file probes (/proc/self/cgroup + the /sys/fs/cgroup hierarchy walk + /proc/meminfo) for the memruns auto budget — read-only host-posture introspection on the load-vehicle knob path, never data-file I/O; Vfs choke routing rides the crate-wide migration
 
-# objkv: Postgres tables in an S3 bucket. The store is a blocking HTTP client
-# by design, the writer and compactor are daemon threads that exist only once
-# the bucket is opened, and the tests reach the fault points through the
-# environment. None of it runs unless a table uses the access method; routing
-# onto the sanctioned surfaces rides objkv's own follow-up, not this ratchet.
-blocking	crates/_support/objkv/src/s3.rs	1	DST-REVIEW(objkv): retry backoff sleep between S3 attempts (ureq, blocking client by design)
-rawsync	crates/_support/objkv/src/run.rs	1	DST-REVIEW(objkv): the per-run block cache mutex, held for a map lookup only
-rawsync	crates/_support/objkv/src/store.rs	1	DST-REVIEW(objkv): the in-memory test store's map mutex
-spawn	crates/_support/objkv/src/lease.rs	1	DST-REVIEW(objkv): the lease heartbeat thread, started once per Db::open, renewing the single-writer lease every HEARTBEAT_MS
-blocking	crates/_support/objkv/src/lease.rs	1	DST-REVIEW(objkv): the heartbeat's 250 ms sleep slices between renewals; the stop flag is checked every slice
-time	crates/_support/objkv/src/lease.rs	1	DST-REVIEW(objkv): SystemClock::now_ms, the wall clock the lease expiry is written in; the Db and lease tests inject a FakeClock
+# objkv: Postgres tables in an S3 bucket. The engine crate uses the sanctioned
+# surfaces (pgsync for threads, sleeps and mutexes; pg_clock for the wall
+# clock); rows below are for what is left.
+blocking	crates/_support/objkv/src/s3.rs	1	DST-REVIEW(objkv): retry backoff between S3 attempts (pgsync::thread::sleep; the client is blocking by design)
+blocking	crates/_support/objkv/src/lease.rs	1	DST-REVIEW(objkv): the heartbeat's 250 ms slices between renewals (pgsync::thread::sleep); the stop flag is checked every slice
+spawn	crates/_support/objkv/src/lease.rs	1	DST-REVIEW(objkv): the lease heartbeat thread (pgsync::thread::Builder), started once per Db::open, renewing the single-writer lease every HEARTBEAT_MS
+join	crates/_support/objkv/src/lease.rs	1	DST-REVIEW(objkv): release/stop_heartbeat join the heartbeat so no renewal is on the wire when the release number is chosen; the thread exits within one 250 ms slice of the stop flag, or after the renewal in flight
+once	crates/_support/objkv/src/lease.rs	1	DST-REVIEW(objkv): the process nonce in Owner::me, a pure init closure over pg_clock and the pid (P3 row-19 pure/env-read)
+rawsync	crates/_support/objkv/src/lease.rs	1	DST-REVIEW(objkv): that nonce's OnceLock; same cell as the once row above

--- a/crates/_support/seams_init/tests/lint-determinism.allow
+++ b/crates/_support/seams_init/tests/lint-determinism.allow
@@ -872,3 +872,15 @@ rawsync	crates/backend/tcop/postgres_seams/src/lib.rs	2	DST-REVIEW(night/stmt-as
 spawn	crates/backend/executor/execmain/src/lanev2/stmt_task.rs	1	DST-REVIEW(night/stmt-as-task-2): the quantum-yield sweeper thread (pgsync::thread::Builder, spawned once on the first armed span under the DEFAULT-OFF PGRUST_STMT_TASK_YIELD; a pure timer/observer on the waiter timed-park surface — the slease-v2 pg-slease-sweeper precedent verbatim; wasm arm cannot exist and the spawn is cfg'd out)
 fs	crates/backend/access/parquet_read/src/lib.rs	5	DST-REVIEW(t46 compose, night/parquet-reader): the reader crate's footer/dictionary/page positioned reads (File::open + pread class, read-only COPY FORMAT parquet source; the branch never paid its ledger — no standard CONFIRM ran there); P1 Vfs choke routing rides the crate-wide migration
 fs	crates/backend/commands/copy/src/memheadroom.rs	2	DST-REVIEW(night/copyfast): kernel pseudo-file probes (/proc/self/cgroup + the /sys/fs/cgroup hierarchy walk + /proc/meminfo) for the memruns auto budget — read-only host-posture introspection on the load-vehicle knob path, never data-file I/O; Vfs choke routing rides the crate-wide migration
+
+# objkv: Postgres tables in an S3 bucket. The store is a blocking HTTP client
+# by design, the writer and compactor are daemon threads that exist only once
+# the bucket is opened, and the tests reach the fault points through the
+# environment. None of it runs unless a table uses the access method; routing
+# onto the sanctioned surfaces rides objkv's own follow-up, not this ratchet.
+blocking	crates/_support/objkv/src/s3.rs	1	DST-REVIEW(objkv): retry backoff sleep between S3 attempts (ureq, blocking client by design)
+rawsync	crates/_support/objkv/src/run.rs	1	DST-REVIEW(objkv): the per-run block cache mutex, held for a map lookup only
+rawsync	crates/_support/objkv/src/store.rs	1	DST-REVIEW(objkv): the in-memory test store's map mutex
+spawn	crates/_support/objkv/src/lease.rs	1	DST-REVIEW(objkv): the lease heartbeat thread, started once per Db::open, renewing the single-writer lease every HEARTBEAT_MS
+blocking	crates/_support/objkv/src/lease.rs	1	DST-REVIEW(objkv): the heartbeat's 250 ms sleep slices between renewals; the stop flag is checked every slice
+time	crates/_support/objkv/src/lease.rs	1	DST-REVIEW(objkv): SystemClock::now_ms, the wall clock the lease expiry is written in; the Db and lease tests inject a FakeClock

--- a/crates/_support/seams_init/tests/lint-determinism.allow
+++ b/crates/_support/seams_init/tests/lint-determinism.allow
@@ -877,7 +877,7 @@ fs	crates/backend/commands/copy/src/memheadroom.rs	2	DST-REVIEW(night/copyfast):
 # surfaces (pgsync for threads, sleeps and mutexes; pg_clock for the wall
 # clock); rows below are for what is left.
 blocking	crates/_support/objkv/src/s3.rs	1	DST-REVIEW(objkv): retry backoff between S3 attempts (pgsync::thread::sleep; the client is blocking by design)
-blocking	crates/_support/objkv/src/lease.rs	1	DST-REVIEW(objkv): the heartbeat's 250 ms slices between renewals (pgsync::thread::sleep); the stop flag is checked every slice
+blocking	crates/_support/objkv/src/lease.rs	1	DST-REVIEW(objkv): the heartbeat parks for 250 ms slices between renewals (pgsync::thread::park_timeout); the stop flag is checked every slice and a stop unparks it
 spawn	crates/_support/objkv/src/lease.rs	1	DST-REVIEW(objkv): the lease heartbeat thread (pgsync::thread::Builder), started once per Db::open, renewing the single-writer lease every HEARTBEAT_MS
 join	crates/_support/objkv/src/lease.rs	1	DST-REVIEW(objkv): release/stop_heartbeat join the heartbeat so no renewal is on the wire when the release number is chosen; the thread exits within one 250 ms slice of the stop flag, or after the renewal in flight
 once	crates/_support/objkv/src/lease.rs	1	DST-REVIEW(objkv): the process nonce in Owner::me, a pure init closure over pg_clock and the pid (P3 row-19 pure/env-read)

--- a/docs/objkv.md
+++ b/docs/objkv.md
@@ -1,0 +1,104 @@
+# objkv: Postgres tables in an object store
+
+objkv is an opt-in table and index access method that keeps rows as
+key/value entries whose durable form is immutable objects in an S3-compatible
+store. Each transaction is one object; the object landing is the commit.
+Local disk is a cache. The system catalogs can be moved into the bucket too
+(the "lift"), after which a blank machine can boot against the bucket.
+
+This document is the contract. Anything not listed under "What works" is
+unsupported, and unsupported operations raise a named error rather than doing
+something quietly different.
+
+## Enabling it
+
+- Set `OBJKV_S3_ENDPOINT`, `OBJKV_S3_BUCKET`, `OBJKV_S3_KEY`, `OBJKV_S3_SECRET`.
+  If the endpoint is unset the server refuses to open objkv storage. There is
+  no memory mode; the in-memory store in the engine crate is a test double.
+  The store is logged at open.
+- `CREATE TABLE ... USING objkv`. Indexes on objkv tables use `objkv_btree`.
+
+## Isolation contract (differs from PostgreSQL)
+
+objkv tables provide snapshot isolation with first-committer-wins validation.
+This is not PostgreSQL's locking model, and the differences are deliberate:
+
+| Situation | PostgreSQL (heap) | objkv |
+|---|---|---|
+| Two transactions update the same row | second blocks until the first commits, then re-evaluates (READ COMMITTED) or fails with 40001 (REPEATABLE READ) | neither blocks; the second to commit fails with 40001 `serialization_failure`, at any isolation level |
+| Two sessions insert the same unique key | second blocks, then 23505 `unique_violation` | second to commit fails with 40001 |
+| Concurrent `INSERT ... ON CONFLICT DO NOTHING/UPDATE` | serialised by the index lock; both succeed | the loser fails with 40001 and must retry |
+| `READ COMMITTED` | each statement sees a fresh snapshot | behaves as REPEATABLE READ: one snapshot for the transaction; conflicts are validated against it |
+| `SELECT ... FOR UPDATE / FOR SHARE / FOR KEY SHARE` | row lock | 0A000 `feature_not_supported`. Foreign keys that reference an objkv table therefore fail loudly. |
+| Row locks, advisory of tuple state (`xmin`, `xmax`, `ctid` stability) | available | `xmin`/`xmax` are not meaningful; `tableoid` is set; TIDs are synthetic and stable within a transaction |
+
+Applications must be prepared to retry on 40001.
+
+## Single writer
+
+One server writes a bucket at a time. Ownership is a lease object with a
+30 s expiry (`objkv::lease::TTL_MS`), renewed every 10 s by a heartbeat
+thread using a conditional write. A second server on the same bucket is
+refused while the lease is live, naming the owner. After a crash the lease
+expires and any host may take over; the takeover bumps an epoch that is
+stamped into every commit object, so a resumed stale writer's later objects
+are ignored and its next PUT is refused. Clean shutdown releases the lease.
+
+## Time travel
+
+`SET pgrust.objkv_snapshot_seq = N` (superuser only) reads the database as
+of commit N. While it is set, writes to objkv tables are refused
+(`cannot write objkv tables while reading a past snapshot`). The forced
+snapshot is registered as in use, so the collector cannot pass it. Reading
+below the collection horizon is refused rather than guessed.
+
+## Indexes
+
+- Supported: equality, ranges, prefix `LIKE`, `IS [NOT] NULL`, `IN` lists,
+  bitmap AND/OR, index-only scans, ordered scans in both directions, partial
+  and expression indexes, `DESC`, `NULLS FIRST/LAST`, multi-column keys,
+  cross-width integer comparisons (`bigint_col = 42`).
+- Text, varchar and char(n) columns must use `COLLATE "C"`; any other
+  collation is refused at `CREATE INDEX` and at insert. `char(n)` compares
+  blank-trimmed, as in PostgreSQL.
+- A scan cannot change direction mid-way (cursor `FETCH BACKWARD` after
+  `FORWARD` errors).
+- Index rows are limited to 400 encoded bytes.
+
+## Storage limits
+
+- No TOAST table. Values are flattened (detoasted and decompressed) before
+  storage; a row that exceeds the objkv row limit fails with 54000
+  `program_limit_exceeded`.
+- Not supported and refused: temp and unlogged objkv tables, `TABLESAMPLE`,
+  parallel scans, `CLUSTER`, `VACUUM FULL`, `ALTER TABLE` rewrites,
+  `SET ACCESS METHOD`.
+- `VACUUM` is a no-op on objkv tables (the compactor and collector run on
+  their own threads). `ANALYZE` works.
+
+## The lift and blank-machine restore
+
+`objkv_lift_verify()` / `objkv_lift()` (superuser) move the system catalogs
+into the bucket. The lift refuses, naming the offenders, when the cluster
+has any user relation that is not already objkv (heap tables, their indexes,
+materialized views), any sequence (so `serial` and identity columns are
+unsupported on a lifted cluster), or any objkv row carrying an external
+TOAST pointer. After the lift, `CREATE DATABASE` is refused.
+
+To restore on a blank machine: `initdb` a fresh data directory, restore the
+objkv marker file, set the S3 variables, start. Static credentials only;
+there is no credentials provider.
+
+## Durability model
+
+- A transaction's object is written at pre-commit. Once it lands it is a
+  commit, even if the client never received the acknowledgement.
+- An abort after the object landed is recorded by a discard marker carrying
+  the xid and object hash; a marker that cannot be written is fatal.
+- Group commit keeps up to eight objects in flight and acknowledges in
+  sequence. A PUT whose response was lost is re-read from the store before
+  it is treated as failed.
+- `pgrust.objkv_async_queue` enables asynchronous commit with a bounded
+  queue; a crash loses at most the queued commits.
+- Old versions stay readable until `pgrust.objkv_retain_commits` commits
+  have been folded and collected.

--- a/docs/objkv.md
+++ b/docs/objkv.md
@@ -40,9 +40,15 @@ One server writes a bucket at a time. Ownership is a lease object with a
 30 s expiry (`objkv::lease::TTL_MS`), renewed every 10 s by a heartbeat
 thread using a conditional write. A second server on the same bucket is
 refused while the lease is live, naming the owner. After a crash the lease
-expires and any host may take over; the takeover bumps an epoch that is
-stamped into every commit object, so a resumed stale writer's later objects
-are ignored and its next PUT is refused. Clean shutdown releases the lease.
+expires and any host may take over (a claimant on the same host that finds
+the owner's pid gone takes over at once); the takeover bumps an epoch that
+is stamped into every commit object, so a resumed stale writer's later
+objects are ignored. The writer also asks the bucket, after each commit
+object lands and before the commit is acknowledged, whether a higher epoch
+has been claimed; if one has, nothing is acknowledged and the server writes
+nothing more. A lease that expires (the store unreachable for the whole
+TTL) is not renewed again: the server refuses writes until it is restarted.
+Clean shutdown releases the lease.
 
 ## Time travel
 
@@ -63,7 +69,8 @@ below the collection horizon is refused rather than guessed.
   blank-trimmed, as in PostgreSQL.
 - A scan cannot change direction mid-way (cursor `FETCH BACKWARD` after
   `FORWARD` errors).
-- Index rows are limited to 400 encoded bytes.
+- Index rows are limited to 2704 encoded bytes (the key is stored hex-encoded,
+  so 5408 bytes in the bucket).
 
 ## Storage limits
 


### PR DESCRIPTION
First of six stacked PRs that replace #92 (closed; 115 files, 22k lines in one commit). Related to #91. Independent fixes split out of #92 as well: #100, #101, #102. Each PR in the stack is one commit, compiles on its own, and its tests pass; the stack is bottom-up so a reviewer can stop at any layer and still have something that builds.

**The stack**

| # | branch | what | lines |
|---|---|---|---|
| 1 | #103 `objkv/1-store` (this) | S3 client, run format, key encodings, lease, fault hooks | ~5.6k (1.1k is Cargo.lock) |
| 2 | #104 `objkv/2-engine` | the LSM engine (`db.rs`), entry scans, fault + isolation harnesses | ~6.8k |
| 3 | #105 `objkv/3-table-am` | `CREATE TABLE ... USING objkv`, core seams, GUCs, commands | ~3.0k |
| 4 | #106 `objkv/4-index-am` | `objkv_btree`, planner/executor hooks | ~2.0k |
| 5 | #107 `objkv/5-lift` | catalogs into the bucket, blank-machine restore | ~1.8k |
| 6 | #108 `objkv/6-e2e-harness` | the shell scripts against MinIO | ~2.7k |

**This PR**

A new leaf crate, `crates/_support/objkv`, with nothing in the server using it yet:

- `s3.rs`: SigV4 client over `ureq` with retries and conditional PUT; a PUT whose response was lost is re-read from the store before it is treated as failed.
- `store.rs`: the `Store` trait the engine writes through, plus the in-memory test double.
- `run.rs` / `bloom.rs` / `commit.rs`: the immutable sorted-block run format with a bloom filter per run, and the commit object one transaction becomes.
- `key.rs` / `index_key.rs`: row-key and order-preserving index-key encodings (integers across widths, text under `COLLATE "C"`, `NULLS FIRST/LAST`, `DESC`).
- `lease.rs`: the single-writer lease (30 s TTL, heartbeat thread, epoch bumped on takeover).
- `faults.rs`: the fault-injection hooks PR 2's tests drive.
- `docs/objkv.md`: the contract for the whole series (isolation model, single writer, time travel, limits). Start there.

New external deps: `ureq` (TLS via rustls) and `rusty-s3`; that is the Cargo.lock delta.

**Test:** `cargo test -p objkv` (90 unit tests). `cargo check --workspace` clean of new warnings.

**Not done (whole series):** benchmark against WAL archiving to S3, differential run against C Postgres, row locks. Conflicts with GOAL.md's same-on-disk-format rule; undecided, and opt-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an opt-in `objkv` table and index access method backed by S3-compatible object storage.
  * Added snapshot isolation, single-writer leasing, time-travel snapshots, immutable storage runs, and ordered index support.
  * Added resilient S3 access with retries, range reads, conditional writes, and integrity validation.
  * Added in-memory storage support for testing and development.

* **Documentation**
  * Documented configuration, durability, supported operations, limits, recovery, and snapshot behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->